### PR TITLE
Fix IDS import defaults and layout

### DIFF
--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -527,7 +527,7 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges }: { node: No
               category: isRecommended ? 'Recommended' : 'All Types'
             }
           })}
-          value={data.dataType || "IFCLABEL"}
+          value={data.dataType || ""}
           onValueChange={(value) => onChange("dataType", value)}
           placeholder="Search data types..."
           searchPlaceholder="Search 60+ data types..."


### PR DESCRIPTION
## Summary
- preserve empty property data types when parsing IDS files instead of forcing IFCLABEL
- reuse the intelligent layout positioning logic during IDS import to avoid overlapping nodes

## Testing
- pnpm lint *(fails: interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_69070b0c23208320971e2a1872f6de37

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-02 08:10:10 UTC

<h3>Greptile Summary</h3>


Improves IDS import by preserving empty property data types and using intelligent layout positioning to prevent node overlaps.

**Key Changes:**
- Replaced manual position calculation (`getFacetPosition`) with intelligent collision-aware `calculateNodePosition` function from `node-layout.ts` for entity, partOf, and facet nodes
- Modified `extractDataType` to return empty string instead of forcing `IFCLABEL` default, preserving original IDS file data
- Updated UI dropdown default from `IFCLABEL` to empty string to match parser behavior

**Issues Found:**
- Export logic in `lib/ids-xml-converter.ts:201` still defaults to `IFCLABEL` when `dataType` is empty, creating an import/export round-trip inconsistency

<h3>Confidence Score: 2/5</h3>


- PR has import/export round-trip data loss issue requiring fix before merge
- Layout improvements are solid, but the dataType changes introduce an inconsistency: empty dataType values imported from IDS files will be preserved in memory but converted back to `IFCLABEL` on export due to fallback logic in `ids-xml-converter.ts:201`. This breaks the stated goal of "preserving empty property data types"
- lib/ids-xml-converter.ts needs updating to handle empty dataType consistently (remove `IFCLABEL` fallback on line 201)

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| lib/ids-xml-parser.ts | 2/5 | Replaced manual position calculation with `calculateNodePosition` for collision-free layouts. Changed `extractDataType` to return empty string instead of `IFCLABEL` default - creates export inconsistency |
| components/inspector-panel.tsx | 5/5 | Changed default value from `IFCLABEL` to empty string for property data type selector - allows truly empty data types in UI |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant IDS as IDS XML File
    participant Parser as ids-xml-parser.ts
    participant Layout as node-layout.ts
    participant UI as inspector-panel.tsx
    participant Converter as ids-xml-converter.ts
    
    Note over IDS,Parser: Import Flow
    IDS->>Parser: Parse IDS XML
    Parser->>Parser: extractDataType(property)
    Note over Parser: Returns "" if no dataType<br/>(was "IFCLABEL" before)
    Parser->>Layout: calculateNodePosition()
    Note over Layout: Intelligent collision detection<br/>(was manual getFacetPosition)
    Layout-->>Parser: Non-overlapping position
    Parser-->>UI: Nodes with empty dataType
    
    Note over UI,Converter: Edit & Export Flow
    UI->>UI: User edits property
    Note over UI: Dropdown shows "" as default<br/>(was "IFCLABEL" before)
    UI->>Converter: Export to IDS XML
    Converter->>Converter: buildPropertyFacet()
    Note over Converter: ISSUE: Falls back to "IFCLABEL"<br/>if dataType is empty (line 201)
    Converter-->>IDS: XML with IFCLABEL default
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->