### PR TITLE
Fix missing property data types defaulting to IFCLABEL

### DIFF
--- a/lib/ids-xml-parser.ts
+++ b/lib/ids-xml-parser.ts
@@ -539,7 +539,7 @@ function extractDataType(property: any): string {
   const dataType = getSimpleValue(property?.dataType)
     || getSimpleValue(property?.datatype)
 
-  return dataType ? dataType.toUpperCase() : "IFCLABEL"
+  return dataType ? dataType.toUpperCase() : ""
 }
 
 function calculateRestrictionPosition(facetPosition: { x: number; y: number }, specPosition: { x: number; y: number }) {


### PR DESCRIPTION
## Summary
- ensure the IDS XML parser leaves property data types blank when none are defined instead of forcing IFCLABEL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907232f265c8320b3ebce59c99e2439

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-02 09:32:19 UTC

<h3>Greptile Summary</h3>


Changed the IDS XML parser to return an empty string instead of `IFCLABEL` when a property's dataType attribute is missing.

**Key changes:**
- Modified `extractDataType()` function to return `""` instead of `"IFCLABEL"` for missing dataType attributes

**Critical issue found:**
- The exporter (`lib/ids-xml-converter.ts:201`) still defaults empty dataType values to `"IFCLABEL"`, creating an import/export roundtrip inconsistency
- Files imported without dataType attributes will be exported with `dataType="IFCLABEL"` added, modifying the original structure

<h3>Confidence Score: 2/5</h3>


- This PR introduces an import/export inconsistency that will modify IDS files on roundtrip
- The parser change is incomplete - it only fixes the import side but leaves the exporter with the old default value, causing files to be modified when imported and re-exported. This breaks the stated goal of avoiding forced defaults.
- Also need to update `lib/ids-xml-converter.ts` to handle empty dataType values consistently

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| lib/ids-xml-parser.ts | 2/5 | Changed default for missing property dataType from `IFCLABEL` to empty string, but this creates import/export inconsistency with the exporter |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant XML as IDS XML File
    participant Parser as ids-xml-parser.ts
    participant Graph as Graph Data Structure
    participant Exporter as ids-xml-converter.ts
    participant Out as Exported XML

    Note over XML: property without<br/>dataType attribute
    
    XML->>Parser: Parse XML
    Parser->>Parser: extractDataType()
    Note over Parser: Missing dataType<br/>returns ""
    Parser->>Graph: Create PropertyNodeData<br/>{dataType: ""}
    
    Note over Graph: User edits/views graph
    
    Graph->>Exporter: Export to XML
    Exporter->>Exporter: buildPropertyFacet()
    Note over Exporter: data.dataType || "IFCLABEL"<br/>"" becomes "IFCLABEL"
    Exporter->>Out: property with<br/>dataType="IFCLABEL"
    
    Note over XML,Out: ⚠️ Inconsistency: Input ≠ Output
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->