### PR TITLE
Fix nonsensical part-of facet relationship types

### DIFF
--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -1132,8 +1132,8 @@ function PartOfFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node
         if (!entityContext.entityName) {
           // Show all spatial relations if no entity connected
           const allRelations = [
-            "IFCRELAGGREGATES", "IFCRELCONTAINEDINSPATIALSTRUCTURE", "IFCRELFILLSELEMENT",
-            "IFCRELVOIDSELEMENT", "IFCRELCONNECTSPATHELEMENTS", "IFCRELCONNECTSPORTS"
+            "IFCRELAGGREGATES", "IFCRELASSIGNSTOGROUP", "IFCRELCONTAINEDINSPATIALSTRUCTURE",
+            "IFCRELNESTS", "IFCRELVOIDSELEMENT", "IFCRELFILLSELEMENT"
           ]
           const relationOptions: SearchableSelectOption[] = allRelations.map(relation => ({
             value: relation,
@@ -1220,11 +1220,11 @@ function PartOfFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="IFCRELAGGREGATES">IFCRELAGGREGATES</SelectItem>
+              <SelectItem value="IFCRELASSIGNSTOGROUP">IFCRELASSIGNSTOGROUP</SelectItem>
               <SelectItem value="IFCRELCONTAINEDINSPATIALSTRUCTURE">IFCRELCONTAINEDINSPATIALSTRUCTURE</SelectItem>
-              <SelectItem value="IFCRELFILLSELEMENT">IFCRELFILLSELEMENT</SelectItem>
+              <SelectItem value="IFCRELNESTS">IFCRELNESTS</SelectItem>
               <SelectItem value="IFCRELVOIDSELEMENT">IFCRELVOIDSELEMENT</SelectItem>
-              <SelectItem value="IFCRELCONNECTSPATHELEMENTS">IFCRELCONNECTSPATHELEMENTS</SelectItem>
-              <SelectItem value="IFCRELCONNECTSPORTS">IFCRELCONNECTSPORTS</SelectItem>
+              <SelectItem value="IFCRELFILLSELEMENT">IFCRELFILLSELEMENT</SelectItem>
             </SelectContent>
           </Select>
         )}

--- a/ids-docs/ids(1).xsd
+++ b/ids-docs/ids(1).xsd
@@ -256,11 +256,12 @@
 	</xs:complexType>
 	<xs:simpleType name="relations">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="IFCRELAGGREGATES"/>  
-			<xs:enumeration value="IFCRELASSIGNSTOGROUP"/> 
-			<xs:enumeration value="IFCRELCONTAINEDINSPATIALSTRUCTURE"/> 
-			<xs:enumeration value="IFCRELNESTS"/> 
-			<xs:enumeration value="IFCRELVOIDSELEMENT IFCRELFILLSELEMENT"/> 
+			<xs:enumeration value="IFCRELAGGREGATES"/>
+			<xs:enumeration value="IFCRELASSIGNSTOGROUP"/>
+			<xs:enumeration value="IFCRELCONTAINEDINSPATIALSTRUCTURE"/>
+			<xs:enumeration value="IFCRELNESTS"/>
+			<xs:enumeration value="IFCRELVOIDSELEMENT"/>
+			<xs:enumeration value="IFCRELFILLSELEMENT"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="upperCaseName">


### PR DESCRIPTION
This commit addresses two critical issues with the part-of facet:

1. XSD Schema: Fixed malformed enumeration that combined two relationship types into a single string value ("IFCRELVOIDSELEMENT IFCRELFILLSELEMENT"). These are now properly separated into individual enumerations.

2. UI Relationship Types: Corrected the relationship options to match the IDS specification. Removed invalid types and added missing ones:

   Removed (invalid for part-of):
   - IFCRELCONNECTSPATHELEMENTS
   - IFCRELCONNECTSPORTS

   Added (required per IDS spec):
   - IFCRELASSIGNSTOGROUP
   - IFCRELNESTS

   Complete valid set per IDS:
   - IFCRELAGGREGATES
   - IFCRELASSIGNSTOGROUP
   - IFCRELCONTAINEDINSPATIALSTRUCTURE
   - IFCRELNESTS
   - IFCRELVOIDSELEMENT
   - IFCRELFILLSELEMENT

These changes ensure the part-of facet correctly supports all 6 valid IFC relationship types as defined in the IDS specification.