### PR TITLE
Fix IDS XML import root-element detection for namespace/case variants

### DIFF
--- a/lib/ids-xml-parser.ts
+++ b/lib/ids-xml-parser.ts
@@ -58,7 +58,7 @@ export function convertIdsXmlToGraph(xml: string): ParsedIdsGraph {
   }
 
   const parsed = parser.parse(xml)
-  const root = parsed?.ids
+  const root = extractIdsRoot(parsed)
   if (!root) {
     throw new Error("Invalid IDS file: missing ids root element")
   }
@@ -185,6 +185,32 @@ export function convertIdsXmlToGraph(xml: string): ParsedIdsGraph {
     ifcVersion: fallbackIfcVersion,
     metadata,
   }
+}
+
+function extractIdsRoot(parsed: unknown): Record<string, any> | null {
+  if (!parsed || typeof parsed !== "object") {
+    return null
+  }
+
+  const asRecord = parsed as Record<string, unknown>
+  if (asRecord.ids && typeof asRecord.ids === "object") {
+    return asRecord.ids as Record<string, any>
+  }
+
+  // Fallback for XML variants where the root key is namespaced or has different casing,
+  // e.g. IDS, ids:ids, ns:IDS.
+  for (const [key, value] of Object.entries(asRecord)) {
+    if (typeof value !== "object" || value === null) {
+      continue
+    }
+
+    const normalized = key.split(":").pop()?.toLowerCase()
+    if (normalized === "ids") {
+      return value as Record<string, any>
+    }
+  }
+
+  return null
 }
 
 interface ApplicabilityContext {


### PR DESCRIPTION
### Motivation
- IDS XML imports were failing when the root element used a namespace or different casing (e.g. `ids:IDS`, `ns:ids`) because the parser only checked `parsed.ids` and rejected valid files.

### Description
- Use a new helper `extractIdsRoot(parsed)` and call it from `convertIdsXmlToGraph` to resolve the IDS root instead of accessing `parsed.ids` directly.
- Added a tolerant fallback that scans top-level keys and accepts names like `ids:IDS`, `IDS`, or `ns:ids` by normalizing the key suffix to lowercase `ids`.
- Change is local to `lib/ids-xml-parser.ts` and preserves the existing fast-path behavior for standard `ids` roots.

### Testing
- Ran a quick inline runtime test with `npx tsx` that imports `convertIdsXmlToGraph` and parses a namespaced sample XML, which returned the expected spec node (success).
- Ran `npm run build` which completed successfully (production build succeeded).
- `npm run lint` could not be executed non-interactively because Next.js prompted for an initial ESLint configuration, so linting was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d2153e0483209bb309127008eb04)