### PR TITLE
Add restriction node type matching to findExistingNode

### DIFF
--- a/lib/node-layout.ts
+++ b/lib/node-layout.ts
@@ -446,6 +446,14 @@ export function findExistingNode(
                 return node.data.value === nodeData.value
             case 'partOf':
                 return node.data.entity === nodeData.entity
+            case 'restriction':
+                return node.data.restrictionType === nodeData.restrictionType &&
+                    node.data.pattern === nodeData.pattern &&
+                    node.data.minValue === nodeData.minValue &&
+                    node.data.maxValue === nodeData.maxValue &&
+                    node.data.minLength === nodeData.minLength &&
+                    node.data.maxLength === nodeData.maxLength &&
+                    JSON.stringify(node.data.values) === JSON.stringify(nodeData.values)
             default:
                 return false
         }


### PR DESCRIPTION
## Summary
Added support for matching restriction-type nodes in the `findExistingNode` function by implementing comparison logic for restriction node data properties.

## Key Changes
- Added a new `case 'restriction'` branch to the node type matching logic in `findExistingNode`
- Implemented comprehensive property comparison for restriction nodes including:
  - `restrictionType`: The type of restriction applied
  - `pattern`: Pattern validation string
  - `minValue` and `maxValue`: Numeric range boundaries
  - `minLength` and `maxLength`: String length boundaries
  - `values`: Array of allowed values (compared via JSON serialization for deep equality)

## Implementation Details
The restriction node matching uses strict equality checks for scalar properties and JSON serialization for the `values` array to ensure proper deep comparison of array contents. This ensures that existing restriction nodes are correctly identified and deduplicated in the node layout system.