### PR TITLE
Fix Select All keyboard shortcut to work without canvas focus

### DIFF
--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -242,13 +242,20 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
   }, [onEdgesChange, onEdgesDelete])
 
   // Handle Select All keyboard shortcut (Cmd+A on Mac, Ctrl+A on Windows)
+  // Attached to window so it works immediately without clicking the canvas first
   useEffect(() => {
-    const container = reactFlowContainerRef.current
-    if (!container) return
-
     const handleKeyDown = (event: KeyboardEvent) => {
-      // Check for Cmd+A (Mac) or Ctrl+A (Windows)
       if ((event.metaKey || event.ctrlKey) && event.key === 'a') {
+        // Let native select-all work inside text inputs and editable elements
+        const el = document.activeElement
+        if (
+          el instanceof HTMLInputElement ||
+          el instanceof HTMLTextAreaElement ||
+          (el instanceof HTMLElement && el.isContentEditable)
+        ) {
+          return
+        }
+
         event.preventDefault()
 
         setNodes((currentNodes) =>
@@ -260,9 +267,9 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
       }
     }
 
-    container.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keydown', handleKeyDown)
     return () => {
-      container.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keydown', handleKeyDown)
     }
   }, [setNodes])
 


### PR DESCRIPTION
## Summary
Modified the Select All keyboard shortcut handler to attach to the window instead of the React Flow container, allowing it to work immediately without requiring the canvas to be focused first. Additionally added logic to respect native text selection behavior in input fields and editable elements.

## Key Changes
- Changed event listener attachment from the React Flow container element to the `window` object, enabling the shortcut to trigger globally
- Added checks to allow native select-all behavior to work in text inputs, textareas, and contenteditable elements
- Improved code organization by moving the element type checks before the preventDefault call

## Implementation Details
The handler now:
1. Listens for Ctrl+A (Windows) or Cmd+A (Mac) at the window level
2. Checks if the active element is a text input, textarea, or contenteditable element
3. Returns early without preventing default behavior if focus is on a text input (allowing native selection)
4. Only prevents default and selects all graph nodes when focus is on the canvas or elsewhere in the document

Fixes #33