### PR TITLE
Persist project state to sessionStorage across navigation

### DIFF
--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -19,6 +19,7 @@ import type { SpecTemplate } from "@/lib/templates"
 import { GraphCanvas } from "./graph-canvas"
 import type { GraphNode, GraphEdge, NodeData, IdsMetadata } from "@/lib/graph-types"
 import { initialNodes, initialEdges } from "@/lib/initial-data"
+import { loadProjectState, saveProjectState } from "@/lib/project-session-store"
 import { convertGraphToIdsXml } from "@/lib/ids-xml-converter"
 import { convertIdsXmlToGraph } from "@/lib/ids-xml-parser"
 import { calculateSmartPositionForNewNode, findTemplateOffset, calculateNodePosition, DEFAULT_LAYOUT_CONFIG, relayoutNodes, findExistingNode } from "@/lib/node-layout"
@@ -33,10 +34,19 @@ export function SpecificationEditor() {
     return supported.includes(value as IFCVersion) ? (value as IFCVersion) : undefined
   }, [])
 
-  const [nodes, setNodes] = useState<GraphNode[]>(initialNodes)
-  const [edges, setEdges] = useState<GraphEdge[]>(initialEdges)
+  const [nodes, setNodes] = useState<GraphNode[]>(() => {
+    const saved = loadProjectState()
+    return saved ? saved.nodes : initialNodes
+  })
+  const [edges, setEdges] = useState<GraphEdge[]>(() => {
+    const saved = loadProjectState()
+    return saved ? saved.edges : initialEdges
+  })
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null)
-  const [ifcVersion, setIfcVersion] = useState<IFCVersion>("IFC4X3_ADD2")
+  const [ifcVersion, setIfcVersion] = useState<IFCVersion>(() => {
+    const saved = loadProjectState()
+    return (saved?.ifcVersion as IFCVersion) || "IFC4X3_ADD2"
+  })
   const [jsonFileInputRef, setJsonFileInputRef] = useState<HTMLInputElement | null>(null)
   const [idsFileInputRef, setIdsFileInputRef] = useState<HTMLInputElement | null>(null)
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
@@ -73,6 +83,11 @@ export function SpecificationEditor() {
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [undo, redo])
+
+  // Persist project state to sessionStorage so it survives navigation (e.g. to /docs and back)
+  useEffect(() => {
+    saveProjectState(nodes, edges, ifcVersion)
+  }, [nodes, edges, ifcVersion])
 
   const updateNodeData = useCallback((nodeId: string, data: any) => {
     console.log('SpecificationEditor updateNodeData:', { nodeId, data })

--- a/lib/project-session-store.ts
+++ b/lib/project-session-store.ts
@@ -1,0 +1,80 @@
+/**
+ * Project Session Store
+ *
+ * Persists project state (nodes, edges, ifcVersion) to sessionStorage so that
+ * navigating away from the editor (e.g. to /docs) and back does not discard
+ * the user's work. sessionStorage is scoped to the browser tab and cleared
+ * when the tab is closed, which is the appropriate lifetime for unsaved work.
+ */
+
+import type { GraphNode, GraphEdge } from "./graph-types"
+
+const STORAGE_KEY = "idsedit-project-state"
+
+interface ProjectState {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+  ifcVersion: string
+}
+
+let cache: ProjectState | null | undefined = undefined
+
+/**
+ * Load project state from sessionStorage.
+ * Returns null if nothing is stored or the data is invalid.
+ * The result is cached for the lifetime of the module so multiple
+ * useState initialisers don't each parse JSON independently.
+ */
+export function loadProjectState(): ProjectState | null {
+  if (cache !== undefined) return cache
+
+  try {
+    if (typeof window === "undefined") {
+      cache = null
+      return null
+    }
+
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) {
+      cache = null
+      return null
+    }
+
+    const parsed = JSON.parse(raw)
+
+    if (
+      !Array.isArray(parsed.nodes) ||
+      !Array.isArray(parsed.edges) ||
+      typeof parsed.ifcVersion !== "string"
+    ) {
+      cache = null
+      return null
+    }
+
+    cache = parsed as ProjectState
+    return cache
+  } catch {
+    cache = null
+    return null
+  }
+}
+
+/**
+ * Save project state to sessionStorage.
+ */
+export function saveProjectState(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  ifcVersion: string
+): void {
+  try {
+    if (typeof window === "undefined") return
+
+    const state: ProjectState = { nodes, edges, ifcVersion }
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+    // Keep cache in sync
+    cache = state
+  } catch (error) {
+    console.warn("Failed to save project state to sessionStorage:", error)
+  }
+}


### PR DESCRIPTION
## Summary
Add session persistence to the specification editor so that project state (nodes, edges, and IFC version) is preserved when users navigate away from the editor and return, without losing their unsaved work.

## Key Changes
- **New module**: `lib/project-session-store.ts` - Provides `loadProjectState()` and `saveProjectState()` functions to manage project state in sessionStorage
  - Includes validation to ensure stored data has the correct structure
  - Implements caching to avoid repeated JSON parsing on multiple state initializations
  - Gracefully handles SSR environments and storage errors
  
- **Updated**: `components/specification-editor.tsx` - Integrated session persistence
  - Initialize `nodes`, `edges`, and `ifcVersion` state from sessionStorage if available, falling back to initial defaults
  - Added `useEffect` hook to automatically save project state whenever nodes, edges, or ifcVersion change

## Implementation Details
- Uses `sessionStorage` (rather than `localStorage`) which is scoped to the browser tab and cleared when the tab closes—appropriate for unsaved work
- State initialization uses lazy initializer functions to avoid unnecessary work on every render
- Caching mechanism prevents redundant JSON parsing when multiple state hooks initialize simultaneously
- Includes error handling and console warnings for storage failures
- Maintains backward compatibility by falling back to initial data if no saved state exists

Closes #32 