### PR TITLE
Add duplicate, copy, and paste functionality for graph nodes

### DIFF
--- a/app/docs/quick-start/page.tsx
+++ b/app/docs/quick-start/page.tsx
@@ -82,9 +82,20 @@ Popular templates:
 
 ## Keyboard Shortcuts
 
-- **Ctrl+Z**: Undo
-- **Ctrl+Shift+Z**: Redo
-- **Delete**: Remove selected nodes/edges
+Use **Ctrl** on Windows/Linux and **⌘ Cmd** on macOS.
+
+- **Ctrl/Cmd+Z**: Undo
+- **Ctrl/Cmd+Shift+Z** (or **Ctrl/Cmd+Y**): Redo
+- **Ctrl/Cmd+A**: Select all nodes
+- **Ctrl/Cmd+D**: Duplicate selected node(s)
+- **Ctrl/Cmd+C**: Copy selected node(s) to the in-canvas clipboard
+- **Ctrl/Cmd+V**: Paste copied node(s)
+- **Delete** / **Backspace**: Remove selected nodes/edges
+
+Duplicate, copy and paste also clone any edges that connect the selected nodes
+to each other, so you can copy a small sub-graph in one shot. Paste places
+copies at an increasing offset so successive pastes don't stack on top of each
+other.
 
 ## Validating Your IDS
 

--- a/app/docs/quick-start/page.tsx
+++ b/app/docs/quick-start/page.tsx
@@ -24,7 +24,10 @@ Every IDS document contains one or more **Specification** nodes. These are the r
 
 1. Look at the left sidebar (Node Palette)
 2. Find the **Specification** node under "Core Nodes"
-3. Drag it onto the canvas
+3. **Drag it onto the canvas** (or click to drop one in the center)
+
+> Tip: every entry in the Node Palette can be dragged and dropped to the
+> exact spot you want, or single-clicked to drop one in the canvas centre.
 
 ### Step 2: Add Applicability Facets
 
@@ -65,6 +68,26 @@ Restrictions define **specific values** that properties or attributes must have.
 2. Set type to "Enumeration"
 3. Add values: "R60", "R90"
 4. Connect it to the Property node's restriction port
+
+#### Shortcut: type multiple values directly
+
+Any single-value field on a facet (Property value, Attribute value, Material
+value, Classification code, …) accepts a bracketed list:
+
+\`\`\`
+[R60, R90, R120]
+\`\`\`
+
+When the editor sees more than one value, an inline **"Make Restriction"**
+button appears below the field. Clicking it:
+
+1. Creates an enumeration **Restriction** node next to the facet
+2. Wires it between the facet and the spec it feeds (preserving
+   applicability/requirements wiring)
+3. Clears the original field, since the values now live on the restriction
+
+This is the recommended way to express "value must be one of X, Y, Z" — a bare
+list in a single value field is not valid IDS XML.
 
 ## Using Templates
 
@@ -136,6 +159,11 @@ You can also:
 3. **Validate Often**: Check your work frequently to catch errors early
 4. **Name Things Clearly**: Use descriptive names for specifications
 5. **Test with Real Models**: Try your IDS files with actual IFC models
+6. **Material names are free-form**: The Material facet's value is just a
+   string per the IDS schema, so you can type any material identifier (e.g.,
+   "oak", "rebar steel B500B") in addition to the suggested presets
+7. **Multiple allowed values?** Use \`[a, b, c]\` on the value field and click
+   "Make Restriction" — single fields can only carry one value in valid IDS
 
 ## Getting Help
 

--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useMemo, useEffect, useState, useRef } from "react"
-import { ReactFlow, Background, BackgroundVariant, Controls, MiniMap, useNodesState, useEdgesState, type Node, type Edge, type Connection, type OnConnect, type OnNodesChange, type OnEdgesChange, NodeChange, EdgeChange } from "@xyflow/react"
+import { ReactFlow, Background, BackgroundVariant, Controls, MiniMap, useNodesState, useEdgesState, useReactFlow, type Node, type Edge, type Connection, type OnConnect, type OnNodesChange, type OnEdgesChange, NodeChange, EdgeChange } from "@xyflow/react"
 import { Map as MapIcon } from "lucide-react"
 import type { GraphNode, GraphEdge } from "@/lib/graph-types"
 import { getEntityContext, isInRequirementsSection } from "@/lib/graph-utils"
@@ -30,6 +30,7 @@ interface GraphCanvasProps {
     sourceEdges: GraphEdge[],
     offset?: { x: number; y: number },
   ) => string[]
+  onAddNode?: (type: string, position: { x: number; y: number }) => void
 }
 
 const nodeTypes = {
@@ -44,13 +45,42 @@ const nodeTypes = {
 }
 
 
-export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes }: GraphCanvasProps) {
+export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes, onAddNode }: GraphCanvasProps) {
   const [showMinimap, setShowMinimap] = useState(true)
   const [focusedSpecTargets, setFocusedSpecTargets] = useState<Record<string, 'applicability' | 'requirements'>>({})
   const [focusedFacetColor, setFocusedFacetColor] = useState<string | null>(null)
   const [focusedSourceNodeId, setFocusedSourceNodeId] = useState<string | null>(null)
   const [isDragging, setIsDragging] = useState(false)
+  const [isDragOver, setIsDragOver] = useState(false)
   const reactFlowContainerRef = useRef<HTMLDivElement>(null)
+  const reactFlowInstance = useReactFlow()
+
+  const onPaletteDragOver = useCallback((event: React.DragEvent) => {
+    if (!event.dataTransfer.types.includes('application/reactflow-node-type')) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'copy'
+    if (!isDragOver) setIsDragOver(true)
+  }, [isDragOver])
+
+  const onPaletteDragLeave = useCallback((event: React.DragEvent) => {
+    // Only clear when leaving the canvas wrapper itself, not its children
+    if (event.currentTarget === event.target) {
+      setIsDragOver(false)
+    }
+  }, [])
+
+  const onPaletteDrop = useCallback((event: React.DragEvent) => {
+    const type = event.dataTransfer.getData('application/reactflow-node-type')
+    if (!type) return
+    event.preventDefault()
+    setIsDragOver(false)
+    if (!onAddNode) return
+    const position = reactFlowInstance.screenToFlowPosition({
+      x: event.clientX,
+      y: event.clientY,
+    })
+    onAddNode(type, position)
+  }, [onAddNode, reactFlowInstance])
 
   // Memoize nodes without focus state to avoid recalculation during selection changes
   const baseNodes: Node[] = useMemo(() =>
@@ -303,6 +333,18 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
     pendingSelectionRef.current = null
   }, [reactFlowNodes, setNodes])
 
+  // Mirror frequently-changing values into refs so the keydown handler effect
+  // below can register the listener once and read fresh values without
+  // re-binding on every selection or position change.
+  const reactFlowNodesRef = useRef(reactFlowNodes)
+  const nodesRef = useRef(nodes)
+  const edgesRef = useRef(edges)
+  const onDuplicateNodesRef = useRef(onDuplicateNodes)
+  useEffect(() => { reactFlowNodesRef.current = reactFlowNodes }, [reactFlowNodes])
+  useEffect(() => { nodesRef.current = nodes }, [nodes])
+  useEffect(() => { edgesRef.current = edges }, [edges])
+  useEffect(() => { onDuplicateNodesRef.current = onDuplicateNodes }, [onDuplicateNodes])
+
   // Handle Duplicate (Cmd/Ctrl+D), Copy (Cmd/Ctrl+C) and Paste (Cmd/Ctrl+V).
   // Mirrors the select-all handler: ignored while the user is typing in inputs
   // so native copy/paste continues to work in text fields.
@@ -319,11 +361,11 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
 
     const getSelectedSource = () => {
       const selectedIds = new Set(
-        reactFlowNodes.filter((n) => n.selected).map((n) => n.id),
+        reactFlowNodesRef.current.filter((n) => n.selected).map((n) => n.id),
       )
       if (selectedIds.size === 0) return null
-      const sourceNodes = nodes.filter((n) => selectedIds.has(n.id))
-      const sourceEdges = edges.filter(
+      const sourceNodes = nodesRef.current.filter((n) => selectedIds.has(n.id))
+      const sourceEdges = edgesRef.current.filter(
         (e) => selectedIds.has(e.source) && selectedIds.has(e.target),
       )
       return { sourceNodes, sourceEdges }
@@ -338,10 +380,10 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
 
       if (key === 'd') {
         event.preventDefault()
-        if (!onDuplicateNodes) return
+        if (!onDuplicateNodesRef.current) return
         const source = getSelectedSource()
         if (!source) return
-        const newIds = onDuplicateNodes(source.sourceNodes, source.sourceEdges, {
+        const newIds = onDuplicateNodesRef.current(source.sourceNodes, source.sourceEdges, {
           x: 40,
           y: 40,
         })
@@ -358,11 +400,11 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
         }
         pasteCountRef.current = 0
       } else if (key === 'v') {
-        if (!onDuplicateNodes || !clipboardRef.current) return
+        if (!onDuplicateNodesRef.current || !clipboardRef.current) return
         event.preventDefault()
         pasteCountRef.current += 1
         const step = 40 * pasteCountRef.current
-        const newIds = onDuplicateNodes(
+        const newIds = onDuplicateNodesRef.current(
           clipboardRef.current.nodes,
           clipboardRef.current.edges,
           { x: step, y: step },
@@ -377,11 +419,19 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [reactFlowNodes, nodes, edges, onDuplicateNodes])
+  }, [])
 
 
   return (
-    <div className="w-full h-full" ref={reactFlowContainerRef} tabIndex={0} style={{ outline: 'none' }}>
+    <div
+      className={`w-full h-full relative transition-colors ${isDragOver ? 'ring-2 ring-inset ring-accent/60 bg-accent/5' : ''}`}
+      ref={reactFlowContainerRef}
+      tabIndex={0}
+      style={{ outline: 'none' }}
+      onDragOver={onPaletteDragOver}
+      onDragLeave={onPaletteDragLeave}
+      onDrop={onPaletteDrop}
+    >
       <ReactFlow
         nodes={reactFlowNodes}
         edges={reactFlowEdges.map(e => ({

--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -25,6 +25,11 @@ interface GraphCanvasProps {
   onConnect: (sourceId: string, targetId: string, targetHandle?: string) => void
   onNodesDelete?: (nodeIds: string[]) => void
   onEdgesDelete?: (edgeIds: string[]) => void
+  onDuplicateNodes?: (
+    sourceNodes: GraphNode[],
+    sourceEdges: GraphEdge[],
+    offset?: { x: number; y: number },
+  ) => string[]
 }
 
 const nodeTypes = {
@@ -39,7 +44,7 @@ const nodeTypes = {
 }
 
 
-export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete }: GraphCanvasProps) {
+export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes }: GraphCanvasProps) {
   const [showMinimap, setShowMinimap] = useState(true)
   const [focusedSpecTargets, setFocusedSpecTargets] = useState<Record<string, 'applicability' | 'requirements'>>({})
   const [focusedFacetColor, setFocusedFacetColor] = useState<string | null>(null)
@@ -272,6 +277,107 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
       window.removeEventListener('keydown', handleKeyDown)
     }
   }, [setNodes])
+
+  // In-memory clipboard for copy/paste of nodes (and their internal edges).
+  // Lives on the canvas so it persists across selection changes within a session
+  // but does not pollute the system clipboard.
+  const clipboardRef = useRef<{ nodes: GraphNode[]; edges: GraphEdge[] } | null>(null)
+  const pasteCountRef = useRef(0)
+  // After a duplicate/paste, mark the new nodes as selected (and clear the previous
+  // selection) once they appear in the canvas state.
+  const pendingSelectionRef = useRef<Set<string> | null>(null)
+
+  useEffect(() => {
+    const pending = pendingSelectionRef.current
+    if (!pending || pending.size === 0) return
+    const allPresent = reactFlowNodes.length > 0 && [...pending].every((id) =>
+      reactFlowNodes.some((n) => n.id === id),
+    )
+    if (!allPresent) return
+    setNodes((currentNodes) =>
+      currentNodes.map((node) => ({
+        ...node,
+        selected: pending.has(node.id),
+      })),
+    )
+    pendingSelectionRef.current = null
+  }, [reactFlowNodes, setNodes])
+
+  // Handle Duplicate (Cmd/Ctrl+D), Copy (Cmd/Ctrl+C) and Paste (Cmd/Ctrl+V).
+  // Mirrors the select-all handler: ignored while the user is typing in inputs
+  // so native copy/paste continues to work in text fields.
+  useEffect(() => {
+    const isEditableTarget = () => {
+      const el = document.activeElement
+      return (
+        el instanceof HTMLInputElement ||
+        el instanceof HTMLTextAreaElement ||
+        el instanceof HTMLSelectElement ||
+        (el instanceof HTMLElement && el.isContentEditable)
+      )
+    }
+
+    const getSelectedSource = () => {
+      const selectedIds = new Set(
+        reactFlowNodes.filter((n) => n.selected).map((n) => n.id),
+      )
+      if (selectedIds.size === 0) return null
+      const sourceNodes = nodes.filter((n) => selectedIds.has(n.id))
+      const sourceEdges = edges.filter(
+        (e) => selectedIds.has(e.source) && selectedIds.has(e.target),
+      )
+      return { sourceNodes, sourceEdges }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey)) return
+      const key = event.key.toLowerCase()
+      if (key !== 'd' && key !== 'c' && key !== 'v') return
+      if (event.shiftKey || event.altKey) return
+      if (isEditableTarget()) return
+
+      if (key === 'd') {
+        event.preventDefault()
+        if (!onDuplicateNodes) return
+        const source = getSelectedSource()
+        if (!source) return
+        const newIds = onDuplicateNodes(source.sourceNodes, source.sourceEdges, {
+          x: 40,
+          y: 40,
+        })
+        if (newIds.length > 0) {
+          pendingSelectionRef.current = new Set(newIds)
+        }
+      } else if (key === 'c') {
+        const source = getSelectedSource()
+        if (!source) return
+        event.preventDefault()
+        clipboardRef.current = {
+          nodes: JSON.parse(JSON.stringify(source.sourceNodes)) as GraphNode[],
+          edges: JSON.parse(JSON.stringify(source.sourceEdges)) as GraphEdge[],
+        }
+        pasteCountRef.current = 0
+      } else if (key === 'v') {
+        if (!onDuplicateNodes || !clipboardRef.current) return
+        event.preventDefault()
+        pasteCountRef.current += 1
+        const step = 40 * pasteCountRef.current
+        const newIds = onDuplicateNodes(
+          clipboardRef.current.nodes,
+          clipboardRef.current.edges,
+          { x: step, y: step },
+        )
+        if (newIds.length > 0) {
+          pendingSelectionRef.current = new Set(newIds)
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [reactFlowNodes, nodes, edges, onDuplicateNodes])
 
 
   return (

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -236,11 +236,15 @@ export function InspectorPanel({
               <div className="space-y-1 text-[11px] text-muted-foreground">
                 <p className="flex items-start gap-1.5">
                   <span className="text-accent">•</span>
-                  <span><kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">Ctrl+Z</kbd> to undo</span>
+                  <span><kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">⌘/Ctrl+Z</kbd> to undo</span>
                 </p>
                 <p className="flex items-start gap-1.5">
                   <span className="text-accent">•</span>
                   <span><kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">⌘/Ctrl</kbd> + click for multi-select</span>
+                </p>
+                <p className="flex items-start gap-1.5">
+                  <span className="text-accent">•</span>
+                  <span><kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">⌘/Ctrl+D</kbd> to duplicate, <kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">⌘/Ctrl+C</kbd>/<kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">V</kbd> to copy &amp; paste</span>
                 </p>
               </div>
             </div>

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -44,7 +44,7 @@ import {
   type CustomPropertySet
 } from "@/lib/custom-schema-store"
 import type { ValidationState } from "@/lib/use-ids-validation"
-import { CheckCircle2, XCircle, AlertCircle, Loader2, RefreshCw, MousePointerClick, Info, Zap, PlusCircle, Link2, Eye, ExternalLink, BookOpen } from "lucide-react"
+import { CheckCircle2, XCircle, AlertCircle, Loader2, RefreshCw, MousePointerClick, Info, Zap, PlusCircle, Link2, Eye, ExternalLink, BookOpen, Filter } from "lucide-react"
 
 interface InspectorPanelProps {
   selectedNode: Node<any> | null
@@ -56,6 +56,53 @@ interface InspectorPanelProps {
   ifcVersion?: IFCVersion
   nodes: GraphNode[]
   edges: GraphEdge[]
+  onConvertValueToRestriction?: (facetNodeId: string, fieldName: string, values: string[]) => void
+}
+
+// Parse a bracketed list like "[R60, R90, R120]" into ["R60", "R90", "R120"].
+// Returns null when the input is not in bracketed form, so callers can keep
+// treating it as a single value.
+export function parseBracketedValueList(input: string): string[] | null {
+  if (typeof input !== 'string') return null
+  const trimmed = input.trim()
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return null
+  const inner = trimmed.slice(1, -1)
+  const parts = inner
+    .split(',')
+    .map((part) => part.trim().replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean)
+  return parts
+}
+
+// Inline button shown beneath a value Input. When the user has typed a
+// bracketed list, offers a one-click conversion that creates an enumeration
+// restriction node wired between the facet and the spec it feeds.
+function ConvertToRestrictionHint({
+  value,
+  onConvert,
+}: {
+  value: string
+  onConvert: (values: string[]) => void
+}) {
+  const parsed = parseBracketedValueList(value)
+  if (!parsed || parsed.length < 2) return null
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-accent/40 bg-accent/5 px-2 py-1.5">
+      <span className="text-[11px] text-muted-foreground">
+        {parsed.length} values detected — convert to a Restriction node?
+      </span>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        className="h-6 px-2 text-[11px]"
+        onClick={() => onConvert(parsed)}
+      >
+        <Filter className="h-3 w-3 mr-1" />
+        Make Restriction
+      </Button>
+    </div>
+  )
 }
 
 // Helper function to check if a facet node is in the requirements section
@@ -129,7 +176,8 @@ export function InspectorPanel({
   isValidationDisabled = false,
   ifcVersion = "IFC4X3_ADD2",
   nodes,
-  edges
+  edges,
+  onConvertValueToRestriction
 }: InspectorPanelProps) {
   if (!selectedNode) {
     return (
@@ -244,7 +292,7 @@ export function InspectorPanel({
                 </p>
                 <p className="flex items-start gap-1.5">
                   <span className="text-accent">•</span>
-                  <span><kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">⌘/Ctrl+D</kbd> to duplicate, <kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">⌘/Ctrl+C</kbd>/<kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">V</kbd> to copy &amp; paste</span>
+                  <span><kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">⌘/Ctrl+D</kbd> to duplicate, <kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">⌘/Ctrl+C</kbd>/<kbd className="px-1 py-0.5 rounded bg-accent/10 border border-border text-[10px] font-mono">⌘/Ctrl+V</kbd> to copy &amp; paste</span>
                 </p>
               </div>
             </div>
@@ -329,10 +377,10 @@ export function InspectorPanel({
           {/* Node Properties */}
           {selectedNode.type === "spec" && <SpecificationFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} />}
           {selectedNode.type === "entity" && <EntityFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
-          {selectedNode.type === "property" && <PropertyFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
-          {selectedNode.type === "attribute" && <AttributeFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
-          {selectedNode.type === "classification" && <ClassificationFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
-          {selectedNode.type === "material" && <MaterialFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
+          {selectedNode.type === "property" && <PropertyFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
+          {selectedNode.type === "attribute" && <AttributeFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
+          {selectedNode.type === "classification" && <ClassificationFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
+          {selectedNode.type === "material" && <MaterialFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
           {selectedNode.type === "partOf" && <PartOfFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
           {selectedNode.type === "restriction" && <RestrictionFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} />}
         </div>
@@ -614,7 +662,7 @@ function EntityFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node
   )
 }
 
-function PropertyFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node<any>; onChange: (field: string, value: any) => void; ifcVersion: IFCVersion; nodes: GraphNode[]; edges: GraphEdge[] }) {
+function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertValueToRestriction }: { node: Node<any>; onChange: (field: string, value: any) => void; ifcVersion: IFCVersion; nodes: GraphNode[]; edges: GraphEdge[]; onConvertValueToRestriction?: (facetNodeId: string, fieldName: string, values: string[]) => void }) {
   const data = node.data as any // Type assertion for now
   const inRequirements = isInRequirementsSection(node.id, edges)
 
@@ -894,7 +942,16 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges }: { node: No
           placeholder={getPlaceholderForDataType(data.dataType)}
           className="bg-input border-border text-foreground"
         />
-        {data.value && (
+        <p className="text-[11px] text-muted-foreground">
+          For multiple allowed values, type <code className="font-mono">[a, b, c]</code> — you can convert to a Restriction node below.
+        </p>
+        {onConvertValueToRestriction && (
+          <ConvertToRestrictionHint
+            value={data.value || ""}
+            onConvert={(values) => onConvertValueToRestriction(node.id, "value", values)}
+          />
+        )}
+        {data.value && !parseBracketedValueList(data.value || "") && (
           <p className="text-xs text-muted-foreground">This property will be used as an applicability condition</p>
         )}
       </div>
@@ -956,7 +1013,7 @@ function getPlaceholderForDataType(dataType?: string): string {
   }
 }
 
-function AttributeFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node<any>; onChange: (field: string, value: any) => void; ifcVersion: IFCVersion; nodes: GraphNode[]; edges: GraphEdge[] }) {
+function AttributeFields({ node, onChange, ifcVersion, nodes, edges, onConvertValueToRestriction }: { node: Node<any>; onChange: (field: string, value: any) => void; ifcVersion: IFCVersion; nodes: GraphNode[]; edges: GraphEdge[]; onConvertValueToRestriction?: (facetNodeId: string, fieldName: string, values: string[]) => void }) {
   const data = node.data as any // Type assertion for now
   const inRequirements = isInRequirementsSection(node.id, edges)
 
@@ -1053,9 +1110,18 @@ function AttributeFields({ node, onChange, ifcVersion, nodes, edges }: { node: N
           id="attribute-value"
           value={data.value || ""}
           onChange={(e) => onChange("value", e.target.value)}
-          placeholder="e.g., Fire Door"
+          placeholder="e.g., Fire Door — or [Fire Door, Exit Door] for multiple"
           className="bg-input border-border text-foreground"
         />
+        <p className="text-[11px] text-muted-foreground">
+          Need several allowed values? Type them as <code className="font-mono">[a, b, c]</code>.
+        </p>
+        {onConvertValueToRestriction && (
+          <ConvertToRestrictionHint
+            value={data.value || ""}
+            onConvert={(values) => onConvertValueToRestriction(node.id, "value", values)}
+          />
+        )}
       </div>
       {inRequirements && (
         <CardinalitySelector
@@ -1083,7 +1149,7 @@ function AttributeFields({ node, onChange, ifcVersion, nodes, edges }: { node: N
   )
 }
 
-function ClassificationFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node<any>; onChange: (field: string, value: any) => void; ifcVersion: IFCVersion; nodes: GraphNode[]; edges: GraphEdge[] }) {
+function ClassificationFields({ node, onChange, ifcVersion, nodes, edges, onConvertValueToRestriction }: { node: Node<any>; onChange: (field: string, value: any) => void; ifcVersion: IFCVersion; nodes: GraphNode[]; edges: GraphEdge[]; onConvertValueToRestriction?: (facetNodeId: string, fieldName: string, values: string[]) => void }) {
   const data = node.data as any // Type assertion for now
   const inRequirements = isInRequirementsSection(node.id, edges)
 
@@ -1184,9 +1250,18 @@ function ClassificationFields({ node, onChange, ifcVersion, nodes, edges }: { no
           id="classification-value"
           value={data.value || ""}
           onChange={(e) => onChange("value", e.target.value)}
-          placeholder="e.g., Pr_20_70_05_05"
+          placeholder="e.g., Pr_20_70_05_05 — or [Pr_20_70_05_05, Pr_20_70_05_06]"
           className="bg-input border-border text-foreground font-mono"
         />
+        <p className="text-[11px] text-muted-foreground">
+          Multiple acceptable codes? Use <code className="font-mono">[a, b, c]</code>.
+        </p>
+        {onConvertValueToRestriction && (
+          <ConvertToRestrictionHint
+            value={data.value || ""}
+            onConvert={(values) => onConvertValueToRestriction(node.id, "value", values)}
+          />
+        )}
       </div>
       {inRequirements && (
         <CardinalitySelector
@@ -1226,7 +1301,7 @@ function ClassificationFields({ node, onChange, ifcVersion, nodes, edges }: { no
   )
 }
 
-function MaterialFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node<any>; onChange: (field: string, value: any) => void; ifcVersion: IFCVersion; nodes: GraphNode[]; edges: GraphEdge[] }) {
+function MaterialFields({ node, onChange, ifcVersion, nodes, edges, onConvertValueToRestriction }: { node: Node<any>; onChange: (field: string, value: any) => void; ifcVersion: IFCVersion; nodes: GraphNode[]; edges: GraphEdge[]; onConvertValueToRestriction?: (facetNodeId: string, fieldName: string, values: string[]) => void }) {
   const data = node.data as any // Type assertion for now
   const inRequirements = isInRequirementsSection(node.id, edges)
 
@@ -1288,38 +1363,27 @@ function MaterialFields({ node, onChange, ifcVersion, nodes, edges }: { node: No
             </span>
           )}
         </Label>
-        {materialOptions.length > 0 ? (
-          <SearchableSelect
-            options={materialOptions}
+        <SearchableSelect
+          options={materialOptions}
+          value={data.value || ""}
+          onValueChange={(value) => onChange("value", value)}
+          placeholder="Search or type a material name..."
+          searchPlaceholder={entityContext.entityName ? `Search materials for ${entityContext.entityName}...` : "Type any material name (e.g., 'oak', 'rebar steel')..."}
+          emptyText="No matching materials — press Enter to use this name"
+          showCategories={true}
+          maxHeight={300}
+          disabled={loading}
+          allowCustom={true}
+          onCreateOption={(name) => onChange("value", name)}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Per the IDS schema, any material name is valid. Type freely, then press Enter — use <code className="font-mono">[a, b, c]</code> for multiple options.
+        </p>
+        {onConvertValueToRestriction && (
+          <ConvertToRestrictionHint
             value={data.value || ""}
-            onValueChange={(value) => onChange("value", value)}
-            placeholder="Search materials..."
-            searchPlaceholder={entityContext.entityName ? `Search materials for ${entityContext.entityName}...` : "Search materials..."}
-            emptyText="No materials found"
-            showCategories={true}
-            maxHeight={300}
-            disabled={loading}
+            onConvert={(values) => onConvertValueToRestriction(node.id, "value", values)}
           />
-        ) : (
-          <Select
-            value={data.value || ""}
-            onValueChange={(value) => onChange("value", value)}
-          >
-            <SelectTrigger className="bg-input border-border text-foreground font-mono">
-              <SelectValue placeholder="Select material" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="concrete">Concrete</SelectItem>
-              <SelectItem value="steel">Steel</SelectItem>
-              <SelectItem value="wood">Wood</SelectItem>
-              <SelectItem value="brick">Brick</SelectItem>
-              <SelectItem value="glass">Glass</SelectItem>
-              <SelectItem value="aluminum">Aluminum</SelectItem>
-              <SelectItem value="plastic">Plastic</SelectItem>
-              <SelectItem value="composite">Composite</SelectItem>
-              <SelectItem value="custom">Custom</SelectItem>
-            </SelectContent>
-          </Select>
         )}
       </div>
       {inRequirements && (

--- a/components/node-palette.tsx
+++ b/components/node-palette.tsx
@@ -61,6 +61,11 @@ export function NodePalette({ onAddNode, ifcVersion }: NodePaletteProps) {
     }
   }
 
+  const handleDragStart = (event: React.DragEvent<HTMLButtonElement>, type: string) => {
+    event.dataTransfer.setData('application/reactflow-node-type', type)
+    event.dataTransfer.effectAllowed = 'copy'
+  }
+
   return (
     <Card className="hidden md:flex md:flex-col w-56 shrink-0 rounded-none border-r border-border bg-sidebar">
       <ScrollArea className="flex-1 min-h-0">
@@ -78,9 +83,12 @@ export function NodePalette({ onAddNode, ifcVersion }: NodePaletteProps) {
                     <Button
                       key={node.type}
                       variant="ghost"
-                      className="node-palette-btn w-full justify-start gap-2 h-auto py-2 hover:bg-sidebar-accent transition-all"
+                      className="node-palette-btn w-full justify-start gap-2 h-auto py-2 hover:bg-sidebar-accent transition-all cursor-grab active:cursor-grabbing"
                       data-facet={node.type}
                       onClick={() => handleAddNode(node.type)}
+                      draggable
+                      onDragStart={(e) => handleDragStart(e, node.type)}
+                      title={`Click or drag to add a ${node.label} node`}
                     >
                       <Icon className={`h-3.5 w-3.5 ${facet?.text ?? "text-primary"} transition-transform group-hover:scale-110`} />
                       <span className="text-xs text-sidebar-foreground">{node.label}</span>

--- a/components/schema-switcher.tsx
+++ b/components/schema-switcher.tsx
@@ -2,6 +2,8 @@
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { HelpCircle } from "lucide-react"
 import type { IFCVersion } from "@/lib/ifc-schema"
 
 interface SchemaSwitcherProps {
@@ -20,8 +22,41 @@ export function SchemaSwitcher({ version, onVersionChange }: SchemaSwitcherProps
 
   return (
     <div className="flex items-center h-8 bg-card border border-border rounded-lg overflow-hidden shadow-sm">
-      <span className="px-3 text-xs text-muted-foreground border-r border-border bg-muted/30">
+      <span className="px-3 text-xs text-muted-foreground border-r border-border bg-muted/30 inline-flex items-center gap-1.5">
         Schema
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="What does Schema mean?"
+              className="text-muted-foreground/70 hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded"
+            >
+              <HelpCircle className="h-3.5 w-3.5" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-80 text-xs space-y-2">
+            <p className="font-semibold text-sm text-foreground">IFC Schema Version</p>
+            <p className="text-muted-foreground">
+              Sets the IFC schema this IDS file targets. The official IDS XSD only
+              accepts these three values:
+            </p>
+            <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+              <li><span className="font-mono">IFC2X3</span> — legacy</li>
+              <li><span className="font-mono">IFC4</span> — widely supported</li>
+              <li><span className="font-mono">IFC4X3_ADD2</span> — latest IDS-recognized</li>
+            </ul>
+            <p className="text-muted-foreground">
+              Newer IFC releases (e.g. IFC4.4) aren&apos;t in the IDS schema yet, so
+              they&apos;re intentionally not listed — picking one would fail XSD
+              validation downstream.
+            </p>
+            <p className="text-muted-foreground">
+              The selection here is also used as the default for any new
+              Specification node you drop on the canvas. You can still override it
+              per-spec from the inspector.
+            </p>
+          </PopoverContent>
+        </Popover>
       </span>
       <Select value={version} onValueChange={(value) => onVersionChange(value as IFCVersion)}>
         <SelectTrigger className="h-full border-0 rounded-none bg-transparent px-3 gap-2 text-sm font-medium min-w-[140px] focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-1">

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -569,6 +569,68 @@ export function SpecificationEditor() {
     return newNodes.map((n) => n.id)
   }, [takeSnapshot])
 
+  // Convert a single facet field carrying multiple values (e.g. "[R60, R90]")
+  // into an enumeration restriction node that sits between the facet and the
+  // spec it feeds. Clears the facet's field after conversion.
+  const convertValueToRestriction = useCallback((
+    facetNodeId: string,
+    fieldName: string,
+    values: string[],
+  ) => {
+    const facet = nodes.find((n) => n.id === facetNodeId)
+    if (!facet) return
+    const cleanValues = values.map((v) => v.trim()).filter(Boolean)
+    if (cleanValues.length === 0) return
+
+    takeSnapshot()
+
+    const timestamp = Date.now()
+    const restrictionId = `restriction-${timestamp}`
+
+    // Position the restriction immediately to the right of the facet
+    const restrictionNode: GraphNode = {
+      id: restrictionId,
+      type: 'restriction',
+      position: { x: facet.position.x + 280, y: facet.position.y },
+      data: {
+        restrictionType: 'enumeration',
+        values: cleanValues,
+      } as NodeData,
+    }
+
+    setNodes((nds) =>
+      nds.map((node) =>
+        node.id === facetNodeId
+          ? { ...node, data: { ...node.data, [fieldName]: '' } }
+          : node,
+      ).concat(restrictionNode),
+    )
+
+    setEdges((eds) => {
+      // Find the existing edge from facet -> spec (if any) and rewire through the restriction
+      const directEdge = eds.find((e) => e.source === facetNodeId)
+      const filtered = directEdge
+        ? eds.filter((e) => e.id !== directEdge.id)
+        : eds
+      const newEdges: GraphEdge[] = [
+        {
+          id: `edge-${timestamp}-fr`,
+          source: facetNodeId,
+          target: restrictionId,
+        },
+      ]
+      if (directEdge) {
+        newEdges.push({
+          id: `edge-${timestamp}-rs`,
+          source: restrictionId,
+          target: directEdge.target,
+          targetHandle: directEdge.targetHandle,
+        })
+      }
+      return [...filtered, ...newEdges]
+    })
+  }, [nodes, takeSnapshot])
+
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">
       {/* Header row */}
@@ -805,6 +867,7 @@ export function SpecificationEditor() {
                 onNodesDelete={handleNodesDelete}
                 onEdgesDelete={handleEdgesDelete}
                 onDuplicateNodes={duplicateNodes}
+                onAddNode={addNode}
               />
             </Panel>
             <CustomPanelResizeHandle />
@@ -819,6 +882,7 @@ export function SpecificationEditor() {
                 ifcVersion={ifcVersion}
                 nodes={nodes}
                 edges={edges}
+                onConvertValueToRestriction={convertValueToRestriction}
               />
             </Panel>
           </PanelGroup>

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -528,6 +528,47 @@ export function SpecificationEditor() {
     setEdges((eds) => eds.filter(edge => !edgeIds.includes(edge.id)))
   }, [takeSnapshot])
 
+  // Duplicate the given nodes (and any edges entirely contained within the selection),
+  // returning the IDs of the newly-created nodes so callers can update selection state.
+  const duplicateNodes = useCallback((
+    sourceNodes: GraphNode[],
+    sourceEdges: GraphEdge[],
+    offset: { x: number; y: number } = { x: 40, y: 40 },
+  ): string[] => {
+    if (sourceNodes.length === 0) return []
+    takeSnapshot() // Capture BEFORE duplication
+
+    const timestamp = Date.now()
+    const idMap = new Map<string, string>()
+
+    const newNodes: GraphNode[] = sourceNodes.map((node, index) => {
+      const newId = `${node.type}-${timestamp}-${index}`
+      idMap.set(node.id, newId)
+      return {
+        ...node,
+        id: newId,
+        position: { x: node.position.x + offset.x, y: node.position.y + offset.y },
+        data: JSON.parse(JSON.stringify(node.data)) as NodeData,
+      }
+    })
+
+    const newEdges: GraphEdge[] = sourceEdges
+      .filter((edge) => idMap.has(edge.source) && idMap.has(edge.target))
+      .map((edge, index) => ({
+        id: `edge-${timestamp}-dup-${index}`,
+        source: idMap.get(edge.source)!,
+        target: idMap.get(edge.target)!,
+        targetHandle: edge.targetHandle,
+      }))
+
+    setNodes((nds) => [...nds, ...newNodes])
+    if (newEdges.length > 0) {
+      setEdges((eds) => [...eds, ...newEdges])
+    }
+
+    return newNodes.map((n) => n.id)
+  }, [takeSnapshot])
+
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">
       {/* Header row */}
@@ -763,6 +804,7 @@ export function SpecificationEditor() {
                 onConnect={handleConnect}
                 onNodesDelete={handleNodesDelete}
                 onEdgesDelete={handleEdgesDelete}
+                onDuplicateNodes={duplicateNodes}
               />
             </Panel>
             <CustomPanelResizeHandle />

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -120,10 +120,10 @@ export function SpecificationEditor() {
       id: `${type}-${Date.now()}`,
       type,
       position: smartPosition,
-      data: getDefaultNodeData(type) as NodeData,
+      data: getDefaultNodeData(type, ifcVersion) as NodeData,
     }
     setNodes((nds) => [...nds, newNode])
-  }, [nodes, edges, takeSnapshot])
+  }, [nodes, edges, ifcVersion, takeSnapshot])
 
   const arrangeAll = useCallback(() => {
     takeSnapshot() // Capture BEFORE rearranging
@@ -900,12 +900,12 @@ export function SpecificationEditor() {
   )
 }
 
-function getDefaultNodeData(type: string) {
+function getDefaultNodeData(type: string, ifcVersion: IFCVersion = "IFC4X3_ADD2") {
   switch (type) {
     case "spec":
       return {
         name: "New Specification",
-        ifcVersion: "IFC4X3_ADD2",
+        ifcVersion,
         description: "",
       }
     case "entity":


### PR DESCRIPTION
## Summary
This PR adds keyboard shortcuts for duplicating, copying, and pasting nodes in the graph canvas. Users can now use Ctrl/Cmd+D to duplicate selected nodes, Ctrl/Cmd+C to copy them to an in-canvas clipboard, and Ctrl/Cmd+V to paste them with an incrementing offset.

## Key Changes

- **GraphCanvas component**: Added `onDuplicateNodes` callback prop and implemented keyboard event handlers for duplicate (Ctrl/Cmd+D), copy (Ctrl/Cmd+C), and paste (Ctrl/Cmd+V) operations
  - Uses an in-memory clipboard (`clipboardRef`) that persists across selection changes within a session without polluting the system clipboard
  - Automatically selects newly created nodes after duplication/paste via `pendingSelectionRef`
  - Respects editable targets (input fields, textareas, etc.) to allow native copy/paste in text fields

- **SpecificationEditor component**: Implemented `duplicateNodes` callback that:
  - Creates new nodes with offset positions
  - Clones internal edges (edges where both source and target are in the selection)
  - Generates unique IDs using timestamps to avoid collisions
  - Captures undo snapshots before duplication
  - Returns new node IDs for selection state updates

- **Documentation**: Updated quick-start guide to document all keyboard shortcuts including the new duplicate/copy/paste functionality and clarified Ctrl/Cmd usage across platforms

- **InspectorPanel**: Updated help text to mention the new duplicate and copy/paste shortcuts alongside existing undo and multi-select hints

## Implementation Details

- The duplicate/copy/paste handlers mirror the existing select-all pattern by checking if the active element is an editable target
- Paste operations increment an offset counter so successive pastes don't stack on top of each other
- Only edges with both source and target nodes in the selection are duplicated, preventing orphaned edges
- Node data is deep-cloned to prevent unintended mutations

https://claude.ai/code/session_014bgQPiZyKEGSUEPN9Zw4EG

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ids-flow/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for duplicating nodes (Cmd/Ctrl+D), copying (Cmd/Ctrl+C), and pasting (Cmd/Ctrl+V)
  * Added on-screen tips for duplicate and copy/paste operations

* **Documentation**
  * Updated quick-start guide with OS-specific keyboard shortcut notation (Ctrl for Windows/Linux, ⌘ Cmd for macOS)
  * Expanded keyboard shortcuts documentation with new duplicate, copy, and paste shortcuts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->