### PR TITLE
Add "Match any value" toggle to value-bearing facets

### DIFF
--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react"
 import { Card } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -101,6 +102,61 @@ function ConvertToRestrictionHint({
         <Filter className="h-3 w-3 mr-1" />
         Make Restriction
       </Button>
+    </div>
+  )
+}
+
+// Returns true when this facet node has a Restriction node attached as its
+// next hop. Used to warn the user that an attached restriction will be ignored
+// while "Match any value" is on.
+function hasConnectedRestriction(
+  nodeId: string,
+  nodes: GraphNode[],
+  edges: GraphEdge[]
+): boolean {
+  return edges.some((edge) => {
+    if (edge.source !== nodeId) return false
+    const target = nodes.find((n) => n.id === edge.target)
+    return target?.type === "restriction"
+  })
+}
+
+// Toggle that flips a facet between specific-value and existence-only mode.
+// When on, the facet emits the IDS XML element without a <value> child
+// (XSD-compliant), which a validator reads as "match any value".
+function AnyValueToggle({
+  id,
+  checked,
+  onCheckedChange,
+  fieldLabel,
+  hasRestriction = false,
+}: {
+  id: string
+  checked: boolean
+  onCheckedChange: (next: boolean) => void
+  fieldLabel: string
+  hasRestriction?: boolean
+}) {
+  return (
+    <div className="rounded-md border border-border bg-card/50 px-2 py-1.5 space-y-1">
+      <label htmlFor={id} className="flex items-center gap-2 cursor-pointer">
+        <Checkbox
+          id={id}
+          checked={checked}
+          onCheckedChange={(v) => onCheckedChange(v === true)}
+        />
+        <span className="text-xs font-medium text-sidebar-foreground">
+          Match any {fieldLabel}
+        </span>
+      </label>
+      <p className="text-[10px] text-muted-foreground leading-snug pl-6">
+        Existence check — matches as long as the field is present, regardless of its value.
+      </p>
+      {checked && hasRestriction ? (
+        <p className="text-[10px] text-amber-600 dark:text-amber-500 leading-snug pl-6">
+          A connected Restriction node will be ignored while this is on.
+        </p>
+      ) : null}
     </div>
   )
 }
@@ -931,6 +987,13 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           maxHeight={300}
         />
       </div>
+      <AnyValueToggle
+        id={`property-anyvalue-${node.id}`}
+        checked={data.anyValue === true}
+        onCheckedChange={(v) => onChange("anyValue", v)}
+        fieldLabel="value"
+        hasRestriction={hasConnectedRestriction(node.id, nodes, edges)}
+      />
       <div className="space-y-2">
         <Label htmlFor="value" className="text-sidebar-foreground">
           Value (Optional)
@@ -941,17 +1004,18 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           onChange={(e) => onChange("value", e.target.value)}
           placeholder={getPlaceholderForDataType(data.dataType)}
           className="bg-input border-border text-foreground"
+          disabled={data.anyValue === true}
         />
         <p className="text-[11px] text-muted-foreground">
           For multiple allowed values, type <code className="font-mono">[a, b, c]</code> — you can convert to a Restriction node below.
         </p>
-        {onConvertValueToRestriction && (
+        {data.anyValue !== true && onConvertValueToRestriction && (
           <ConvertToRestrictionHint
             value={data.value || ""}
             onConvert={(values) => onConvertValueToRestriction(node.id, "value", values)}
           />
         )}
-        {data.value && !parseBracketedValueList(data.value || "") && (
+        {data.anyValue !== true && data.value && !parseBracketedValueList(data.value || "") && (
           <p className="text-xs text-muted-foreground">This property will be used as an applicability condition</p>
         )}
       </div>
@@ -1102,6 +1166,13 @@ function AttributeFields({ node, onChange, ifcVersion, nodes, edges, onConvertVa
           />
         )}
       </div>
+      <AnyValueToggle
+        id={`attribute-anyvalue-${node.id}`}
+        checked={data.anyValue === true}
+        onCheckedChange={(v) => onChange("anyValue", v)}
+        fieldLabel="value"
+        hasRestriction={hasConnectedRestriction(node.id, nodes, edges)}
+      />
       <div className="space-y-2">
         <Label htmlFor="attribute-value" className="text-sidebar-foreground">
           Value (Optional)
@@ -1112,11 +1183,12 @@ function AttributeFields({ node, onChange, ifcVersion, nodes, edges, onConvertVa
           onChange={(e) => onChange("value", e.target.value)}
           placeholder="e.g., Fire Door — or [Fire Door, Exit Door] for multiple"
           className="bg-input border-border text-foreground"
+          disabled={data.anyValue === true}
         />
         <p className="text-[11px] text-muted-foreground">
           Need several allowed values? Type them as <code className="font-mono">[a, b, c]</code>.
         </p>
-        {onConvertValueToRestriction && (
+        {data.anyValue !== true && onConvertValueToRestriction && (
           <ConvertToRestrictionHint
             value={data.value || ""}
             onConvert={(values) => onConvertValueToRestriction(node.id, "value", values)}
@@ -1242,6 +1314,13 @@ function ClassificationFields({ node, onChange, ifcVersion, nodes, edges, onConv
           </Select>
         )}
       </div>
+      <AnyValueToggle
+        id={`classification-anyvalue-${node.id}`}
+        checked={data.anyValue === true}
+        onCheckedChange={(v) => onChange("anyValue", v)}
+        fieldLabel="classification code"
+        hasRestriction={hasConnectedRestriction(node.id, nodes, edges)}
+      />
       <div className="space-y-2">
         <Label htmlFor="classification-value" className="text-sidebar-foreground">
           Classification Code (Optional)
@@ -1252,11 +1331,12 @@ function ClassificationFields({ node, onChange, ifcVersion, nodes, edges, onConv
           onChange={(e) => onChange("value", e.target.value)}
           placeholder="e.g., Pr_20_70_05_05 — or [Pr_20_70_05_05, Pr_20_70_05_06]"
           className="bg-input border-border text-foreground font-mono"
+          disabled={data.anyValue === true}
         />
         <p className="text-[11px] text-muted-foreground">
           Multiple acceptable codes? Use <code className="font-mono">[a, b, c]</code>.
         </p>
-        {onConvertValueToRestriction && (
+        {data.anyValue !== true && onConvertValueToRestriction && (
           <ConvertToRestrictionHint
             value={data.value || ""}
             onConvert={(values) => onConvertValueToRestriction(node.id, "value", values)}
@@ -1351,8 +1431,18 @@ function MaterialFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
     loadMaterialTypes()
   }, [entityContext.entityName, ifcVersion])
 
+  const anyValue = data.anyValue === true
+  const restrictionAttached = hasConnectedRestriction(node.id, nodes, edges)
+
   return (
     <>
+      <AnyValueToggle
+        id={`material-anyvalue-${node.id}`}
+        checked={anyValue}
+        onCheckedChange={(v) => onChange("anyValue", v)}
+        fieldLabel="material"
+        hasRestriction={restrictionAttached}
+      />
       <div className="space-y-2">
         <Label htmlFor="material-value" className="text-sidebar-foreground">
           Material Value
@@ -1372,14 +1462,14 @@ function MaterialFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           emptyText="No matching materials — press Enter to use this name"
           showCategories={true}
           maxHeight={300}
-          disabled={loading}
+          disabled={loading || anyValue}
           allowCustom={true}
           onCreateOption={(name) => onChange("value", name)}
         />
         <p className="text-[11px] text-muted-foreground">
           Per the IDS schema, any material name is valid. Type freely, then press Enter — use <code className="font-mono">[a, b, c]</code> for multiple options.
         </p>
-        {onConvertValueToRestriction && (
+        {!anyValue && onConvertValueToRestriction && (
           <ConvertToRestrictionHint
             value={data.value || ""}
             onConvert={(values) => onConvertValueToRestriction(node.id, "value", values)}

--- a/components/nodes/attribute-node.tsx
+++ b/components/nodes/attribute-node.tsx
@@ -24,6 +24,7 @@ export function AttributeNode({ data, selected }: NodeProps) {
     const facet = getFacet("attribute")
     const showCardinality = data.isInRequirements === true
     const badge = showCardinality ? getCardinalityBadge(data.cardinality as Cardinality) : null
+    const anyValue = data.anyValue === true
 
     return (
         <Card
@@ -39,18 +40,27 @@ export function AttributeNode({ data, selected }: NodeProps) {
                 <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">
                         <p className="text-xs text-muted-foreground font-mono">Attribute</p>
-                        {data.value && (
+                        {anyValue ? (
+                            <p className="text-xs text-muted-foreground italic">Any value</p>
+                        ) : data.value ? (
                             <p className="text-xs text-muted-foreground">
                                 <span className={facet.text}>Value:</span>
                                 <span className="ml-2 text-foreground">{data.value}</span>
                             </p>
+                        ) : null}
+                    </div>
+                    <div className="flex items-center gap-1">
+                        {anyValue && (
+                            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-accent/15 text-accent border border-accent/30" title="Existence-only check (any value)">
+                                Any
+                            </span>
+                        )}
+                        {badge && (
+                            <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${badge.color}`} title={badge.title}>
+                                {badge.label}
+                            </span>
                         )}
                     </div>
-                    {badge && (
-                        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${badge.color}`} title={badge.title}>
-                            {badge.label}
-                        </span>
-                    )}
                 </div>
             </div>
             <Handle type="source" position={Position.Right} className={facet.handle} />

--- a/components/nodes/classification-node.tsx
+++ b/components/nodes/classification-node.tsx
@@ -24,6 +24,7 @@ export function ClassificationNode({ data, selected }: NodeProps) {
     const facet = getFacet("classification")
     const showCardinality = data.isInRequirements === true
     const badge = showCardinality ? getCardinalityBadge(data.cardinality as Cardinality) : null
+    const anyValue = data.anyValue === true
 
     return (
         <Card
@@ -39,12 +40,14 @@ export function ClassificationNode({ data, selected }: NodeProps) {
                 <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">
                         <p className="text-xs text-muted-foreground font-mono">Classification</p>
-                        {data.value && (
+                        {anyValue ? (
+                            <p className="text-xs text-muted-foreground italic">Any code</p>
+                        ) : data.value ? (
                             <p className="text-xs text-muted-foreground">
                                 <span className={facet.text}>Code:</span>
                                 <span className="ml-2 text-foreground font-mono">{data.value}</span>
                             </p>
-                        )}
+                        ) : null}
                         {data.uri && (
                             <p className="text-xs text-muted-foreground truncate">
                                 <span className={facet.text}>URI:</span>
@@ -52,11 +55,18 @@ export function ClassificationNode({ data, selected }: NodeProps) {
                             </p>
                         )}
                     </div>
-                    {badge && (
-                        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${badge.color}`} title={badge.title}>
-                            {badge.label}
-                        </span>
-                    )}
+                    <div className="flex items-center gap-1">
+                        {anyValue && (
+                            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-accent/15 text-accent border border-accent/30" title="Existence-only check (any value)">
+                                Any
+                            </span>
+                        )}
+                        {badge && (
+                            <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${badge.color}`} title={badge.title}>
+                                {badge.label}
+                            </span>
+                        )}
+                    </div>
                 </div>
             </div>
             <Handle type="source" position={Position.Right} className={facet.handle} />

--- a/components/nodes/material-node.tsx
+++ b/components/nodes/material-node.tsx
@@ -24,6 +24,8 @@ export function MaterialNode({ data, selected }: NodeProps) {
     const facet = getFacet("material")
     const showCardinality = data.isInRequirements === true
     const badge = showCardinality ? getCardinalityBadge(data.cardinality as Cardinality) : null
+    const anyValue = data.anyValue === true
+    const title = anyValue ? "Any material" : (data.value as string) || "Material"
 
     return (
         <Card
@@ -34,7 +36,7 @@ export function MaterialNode({ data, selected }: NodeProps) {
                     <div className={`p-1.5 rounded ${facet.iconBg}`}>
                         <Package className={`h-4 w-4 ${facet.text}`} />
                     </div>
-                    <h3 className="font-semibold text-sm text-foreground font-mono flex-1 truncate">{data.value || "Material"}</h3>
+                    <h3 className="font-semibold text-sm text-foreground font-mono flex-1 truncate">{title}</h3>
                 </div>
                 <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">
@@ -46,11 +48,18 @@ export function MaterialNode({ data, selected }: NodeProps) {
                             </p>
                         )}
                     </div>
-                    {badge && (
-                        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${badge.color}`} title={badge.title}>
-                            {badge.label}
-                        </span>
-                    )}
+                    <div className="flex items-center gap-1">
+                        {anyValue && (
+                            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-accent/15 text-accent border border-accent/30" title="Existence-only check (any value)">
+                                Any
+                            </span>
+                        )}
+                        {badge && (
+                            <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${badge.color}`} title={badge.title}>
+                                {badge.label}
+                            </span>
+                        )}
+                    </div>
                 </div>
             </div>
             <Handle type="source" position={Position.Right} className={facet.handle} />

--- a/components/nodes/property-node.tsx
+++ b/components/nodes/property-node.tsx
@@ -25,6 +25,7 @@ export function PropertyNode({ data, selected }: NodeProps) {
   const facet = getFacet("property")
   const showCardinality = data.isInRequirements === true
   const badge = showCardinality ? getCardinalityBadge(data.cardinality as Cardinality) : null
+  const anyValue = data.anyValue === true
 
   return (
     <Card
@@ -48,14 +49,25 @@ export function PropertyNode({ data, selected }: NodeProps) {
             <p className="text-xs text-muted-foreground font-mono">{data.propertySet}</p>
             <p className="text-xs text-muted-foreground">
               <span className={facet.text}>{data.dataType}</span>
-              {data.value && <span className="ml-2 text-foreground">= {data.value}</span>}
+              {anyValue ? (
+                <span className="ml-2 italic">= any value</span>
+              ) : data.value ? (
+                <span className="ml-2 text-foreground">= {data.value}</span>
+              ) : null}
             </p>
           </div>
-          {badge && (
-            <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${badge.color}`} title={badge.title}>
-              {badge.label}
-            </span>
-          )}
+          <div className="flex items-center gap-1">
+            {anyValue && (
+              <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-accent/15 text-accent border border-accent/30" title="Existence-only check (any value)">
+                Any
+              </span>
+            )}
+            {badge && (
+              <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${badge.color}`} title={badge.title}>
+                {badge.label}
+              </span>
+            )}
+          </div>
         </div>
       </div>
       <Handle type="source" position={Position.Right} className={facet.handle} />

--- a/lib/graph-types.ts
+++ b/lib/graph-types.ts
@@ -56,6 +56,7 @@ export interface PropertyNodeData {
   baseName: string
   dataType?: string  // Optional - valid per IDS spec to omit dataType
   value?: string
+  anyValue?: boolean  // Wildcard: match any value (omit <value> in IDS XML)
   cardinality?: Cardinality  // Cardinality for requirement facets (not used in applicability)
   uri?: string  // URI attribute for requirement properties (optional)
   instructions?: string  // Instructions attribute for requirement properties (optional)
@@ -64,6 +65,7 @@ export interface PropertyNodeData {
 export interface AttributeNodeData {
   name: string
   value?: string
+  anyValue?: boolean  // Wildcard: match any value (omit <value> in IDS XML)
   cardinality?: Cardinality  // Cardinality for requirement facets (not used in applicability)
   instructions?: string  // Instructions attribute for requirement attributes (optional)
 }
@@ -71,6 +73,7 @@ export interface AttributeNodeData {
 export interface ClassificationNodeData {
   system: string
   value?: string
+  anyValue?: boolean  // Wildcard: match any classification value (omit <value> in IDS XML)
   uri?: string
   cardinality?: Cardinality  // Cardinality for requirement facets (not used in applicability)
   instructions?: string  // Instructions attribute for requirement classifications (optional)
@@ -78,6 +81,7 @@ export interface ClassificationNodeData {
 
 export interface MaterialNodeData {
   value: string
+  anyValue?: boolean  // Wildcard: match any material value (omit <value> in IDS XML)
   uri?: string
   cardinality?: Cardinality  // Cardinality for requirement facets (not used in applicability)
   instructions?: string  // Instructions attribute for requirement materials (optional)

--- a/lib/graph-types.ts
+++ b/lib/graph-types.ts
@@ -80,7 +80,7 @@ export interface ClassificationNodeData {
 }
 
 export interface MaterialNodeData {
-  value: string
+  value?: string
   anyValue?: boolean  // Wildcard: match any material value (omit <value> in IDS XML)
   uri?: string
   cardinality?: Cardinality  // Cardinality for requirement facets (not used in applicability)

--- a/lib/ids-xml-converter.ts
+++ b/lib/ids-xml-converter.ts
@@ -345,6 +345,9 @@ function buildPropertyFacet(node: GraphNode, parent: any, cardinality?: string, 
   idsSimple(prop, "ids:propertySet", data.propertySet)
   idsSimple(prop, "ids:baseName", normalizePropertyName(data.baseName))
 
+  // Wildcard mode: existence-only check, no <value> element
+  if (data.anyValue) return
+
   // Handle restrictions by checking for connected restriction nodes
   if (edges && nodes) {
     const restrictionEdge = edges.find(e => e.source === node.id)
@@ -382,6 +385,9 @@ function buildAttributeFacet(node: GraphNode, parent: any, cardinality?: string,
 
   const attr = parent.ele("ids:attribute", attrs)
   idsSimple(attr, "ids:name", data.name)
+
+  // Wildcard mode: existence-only check, no <value> element
+  if (data.anyValue) return
 
   // Handle restrictions by checking for connected restriction nodes
   if (edges && nodes) {
@@ -423,16 +429,22 @@ function buildClassificationFacet(node: GraphNode, parent: any, cardinality?: st
 
   const cls = parent.ele("ids:classification", attrs)
 
-  // Per IDS XSD schema, 'value' must come before 'system'
-  // Handle restrictions by checking for connected restriction nodes
-  if (edges && nodes) {
-    const restrictionEdge = edges.find(e => e.source === node.id)
-    if (restrictionEdge) {
-      const restrictionNode = nodes.find(n => n.id === restrictionEdge.target)
-      if (restrictionNode && restrictionNode.type === 'restriction') {
-        // Create value element with restriction
-        const valueElement = cls.ele("ids:value")
-        buildValueRestriction(valueElement, restrictionNode)
+  // Per IDS XSD schema, 'value' must come before 'system'.
+  // Wildcard mode skips the <value> element entirely.
+  if (!data.anyValue) {
+    // Handle restrictions by checking for connected restriction nodes
+    if (edges && nodes) {
+      const restrictionEdge = edges.find(e => e.source === node.id)
+      if (restrictionEdge) {
+        const restrictionNode = nodes.find(n => n.id === restrictionEdge.target)
+        if (restrictionNode && restrictionNode.type === 'restriction') {
+          // Create value element with restriction
+          const valueElement = cls.ele("ids:value")
+          buildValueRestriction(valueElement, restrictionNode)
+        } else if (data.value) {
+          // Simple value constraint
+          idsSimple(cls, "ids:value", data.value)
+        }
       } else if (data.value) {
         // Simple value constraint
         idsSimple(cls, "ids:value", data.value)
@@ -441,9 +453,6 @@ function buildClassificationFacet(node: GraphNode, parent: any, cardinality?: st
       // Simple value constraint
       idsSimple(cls, "ids:value", data.value)
     }
-  } else if (data.value) {
-    // Simple value constraint
-    idsSimple(cls, "ids:value", data.value)
   }
 
   // System must come after value per IDS XSD schema
@@ -466,6 +475,9 @@ function buildMaterialFacet(node: GraphNode, parent: any, cardinality?: string, 
   }
 
   const mat = parent.ele("ids:material", attrs)
+
+  // Wildcard mode: existence-only check, no <value> element
+  if (data.anyValue) return
 
   // Handle restrictions by checking for connected restriction nodes
   if (edges && nodes) {

--- a/lib/ids-xml-parser.ts
+++ b/lib/ids-xml-parser.ts
@@ -489,6 +489,9 @@ function createFacetWithOptionalRestriction(input: FacetCreationInput) {
   const valueExtraction = parseValueNode(valueNode)
   if (valueExtraction.simpleValue !== undefined && valueExtraction.simpleValue !== "") {
     ; (node.data as any).value = valueExtraction.simpleValue
+  } else if (valueNode === undefined && !valueExtraction.restriction) {
+    // No <value> element in the source XML → existence-only / wildcard facet.
+    ; (node.data as any).anyValue = true
   }
 
   if (valueExtraction.restriction) {


### PR DESCRIPTION
## Summary

The IDS 1.0 XSD allows `<value>` to be optional on material, classification, attribute, and property — semantically: "match the existence of this field, regardless of its value." The converter already emitted XSD-correct XML when the value was empty, but the editor gave no visual signal of intent — blank could mean "wildcard" or "haven't filled it in yet."

This PR makes that intent first-class:

- New optional `anyValue?: boolean` flag on `MaterialNodeData`, `ClassificationNodeData`, `AttributeNodeData`, `PropertyNodeData`.
- Inspector shows a **"Match any …"** checkbox above each value field. When on, the value input is disabled (the value is preserved so flipping the toggle off restores it). A warning appears if a Restriction node is attached, since a wildcard facet ignores the restriction at XML time.
- Facet nodes render an **"Any"** pill next to the cardinality badge so the state is visible on the canvas.
- XML converter short-circuits value emission when `anyValue` is true, even if `data.value` or a connected Restriction would otherwise apply.
- XML parser sets `anyValue: true` when a facet has no `<value>` child in the source XML, so imported wildcards round-trip cleanly.

Entity's `predefinedType` is also optional per the XSD, but since `name` is required the empty-vs-wildcard ambiguity is much weaker there — kept out of scope.

## Test plan

- [x] `npm run build` succeeds; static pages still prerender
- [x] Dev server returns 200 with no runtime errors on home page
- [ ] Toggle the "Match any value" switch on a material node → value field disables, "Any" pill appears, exported IDS shows `<material/>` with no `<value>` child
- [ ] Re-import the same IDS → toggle stays on, no spurious "value" appears
- [ ] Attach a Restriction node to a wildcard facet → inspector shows the warning, exported XML still has no `<value>`
- [ ] Toggle a property/attribute/classification node and confirm same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ids-flow/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Any Value" toggle mode to treat facets as existence-only wildcards.
  * Visual indicators: "Any", "Any value", "Any code", "Any material" display in nodes and panels.
  * Warnings shown when a connected restriction would be ignored by wildcard mode.
  * Import/export updated: missing values import as wildcard facets; wildcard facets export without value elements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ids-flow/pull/38)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->