### PR TITLE
Make material wildcard behavior consistent with other facets

### DIFF
--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -93,6 +93,14 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
     nodes.map(node => {
       const entityContext = getEntityContext(node.id, nodes, edges)
       const inRequirements = isInRequirementsSection(node.id, edges)
+      // A value-bearing facet with an attached restriction is not a wildcard
+      // (the restriction node still constrains the value at XML emission),
+      // so node components use this to suppress the "Any …" hint.
+      const hasRestriction = edges.some(edge => {
+        if (edge.source !== node.id) return false
+        const target = nodes.find(n => n.id === edge.target)
+        return target?.type === 'restriction'
+      })
       return {
         id: node.id,
         type: node.type,
@@ -101,6 +109,7 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
           ...node.data,
           entityContext: entityContext.entityName,
           isInRequirements: inRequirements,
+          hasRestriction,
         },
       }
     }), [nodes, edges]

--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -33,6 +33,13 @@ interface GraphCanvasProps {
     offset?: { x: number; y: number },
   ) => string[]
   onAddNode?: (type: string, position: { x: number; y: number }) => void
+  /**
+   * Newly created nodes that should become the current selection as soon as
+   * they're present in ReactFlow's internal node state. Owned by spec-editor;
+   * the canvas clears it via onPendingSelectionConsumed after applying.
+   */
+  pendingSelectionIds?: string[] | null
+  onPendingSelectionConsumed?: () => void
   validationState?: ValidationState
   isValidating?: boolean
   isValidationDisabled?: boolean
@@ -51,7 +58,7 @@ const nodeTypes = {
 }
 
 
-export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes, onAddNode, validationState, isValidating = false, isValidationDisabled = false, onValidateNow }: GraphCanvasProps) {
+export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes, onAddNode, pendingSelectionIds, onPendingSelectionConsumed, validationState, isValidating = false, isValidationDisabled = false, onValidateNow }: GraphCanvasProps) {
   const [showMinimap, setShowMinimap] = useState(true)
   const [focusedSpecTargets, setFocusedSpecTargets] = useState<Record<string, 'applicability' | 'requirements'>>({})
   const [focusedFacetColor, setFocusedFacetColor] = useState<string | null>(null)
@@ -175,18 +182,24 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
     })
   }, [baseNodes]) // Only depend on baseNodes, not on isDragging state changes
 
-  // Separate effect to update only focus/highlight data without recreating nodes
+  // Update only the spec nodes' highlight data on focus changes.
+  // Skipping non-spec nodes avoids creating new object refs for every node on
+  // every selection — they don't consume highlight props anyway.
   useEffect(() => {
     setNodes((currentNodes) =>
-      currentNodes.map(node => ({
-        ...node,
-        data: {
-          ...node.data,
-          highlightTarget: (node.type === 'spec' && focusedSpecTargets[node.id]) ? focusedSpecTargets[node.id] : undefined,
-          highlightColor: (focusedFacetColor && node.type === 'spec') ? focusedFacetColor : undefined,
-          highlightSourceId: (node.type === 'spec' && focusedSpecTargets[node.id]) ? focusedSourceNodeId : undefined,
-        },
-      }))
+      currentNodes.map(node => {
+        if (node.type !== 'spec') return node
+        const targetForThis = focusedSpecTargets[node.id]
+        return {
+          ...node,
+          data: {
+            ...node.data,
+            highlightTarget: targetForThis ?? undefined,
+            highlightColor: targetForThis ? (focusedFacetColor ?? undefined) : undefined,
+            highlightSourceId: targetForThis ? (focusedSourceNodeId ?? undefined) : undefined,
+          },
+        }
+      })
     )
   }, [focusedSpecTargets, focusedFacetColor, focusedSourceNodeId, setNodes])
 
@@ -328,25 +341,24 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
   // but does not pollute the system clipboard.
   const clipboardRef = useRef<{ nodes: GraphNode[]; edges: GraphEdge[] } | null>(null)
   const pasteCountRef = useRef(0)
-  // After a duplicate/paste, mark the new nodes as selected (and clear the previous
-  // selection) once they appear in the canvas state.
-  const pendingSelectionRef = useRef<Set<string> | null>(null)
 
+  // Apply spec-editor's pending-selection request as soon as the new nodes are
+  // present in ReactFlow's internal state. spec-editor owns the state; we just
+  // flip `selected` on the matching nodes and signal back when done.
   useEffect(() => {
-    const pending = pendingSelectionRef.current
-    if (!pending || pending.size === 0) return
-    const allPresent = reactFlowNodes.length > 0 && [...pending].every((id) =>
-      reactFlowNodes.some((n) => n.id === id),
-    )
+    if (!pendingSelectionIds || pendingSelectionIds.length === 0) return
+    const ids = new Set(pendingSelectionIds)
+    const allPresent =
+      reactFlowNodes.length > 0 && [...ids].every((id) => reactFlowNodes.some((n) => n.id === id))
     if (!allPresent) return
     setNodes((currentNodes) =>
       currentNodes.map((node) => ({
         ...node,
-        selected: pending.has(node.id),
+        selected: ids.has(node.id),
       })),
     )
-    pendingSelectionRef.current = null
-  }, [reactFlowNodes, setNodes])
+    onPendingSelectionConsumed?.()
+  }, [pendingSelectionIds, reactFlowNodes, setNodes, onPendingSelectionConsumed])
 
   // Mirror frequently-changing values into refs so the keydown handler effect
   // below can register the listener once and read fresh values without
@@ -398,13 +410,12 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
         if (!onDuplicateNodesRef.current) return
         const source = getSelectedSource()
         if (!source) return
-        const newIds = onDuplicateNodesRef.current(source.sourceNodes, source.sourceEdges, {
+        // duplicateNodes (in spec-editor) sets pendingSelectionIds itself;
+        // we don't need to capture the returned IDs here.
+        onDuplicateNodesRef.current(source.sourceNodes, source.sourceEdges, {
           x: 40,
           y: 40,
         })
-        if (newIds.length > 0) {
-          pendingSelectionRef.current = new Set(newIds)
-        }
       } else if (key === 'c') {
         const source = getSelectedSource()
         if (!source) return
@@ -419,14 +430,11 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
         event.preventDefault()
         pasteCountRef.current += 1
         const step = 40 * pasteCountRef.current
-        const newIds = onDuplicateNodesRef.current(
+        onDuplicateNodesRef.current(
           clipboardRef.current.nodes,
           clipboardRef.current.edges,
           { x: step, y: step },
         )
-        if (newIds.length > 0) {
-          pendingSelectionRef.current = new Set(newIds)
-        }
       }
     }
 

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -30,8 +30,6 @@ import {
   getAllEntities,
   getPropertySetsForEntityAsync,
   getAttributesForEntity,
-  getClassificationSystemsForEntity,
-  getMaterialTypesForEntity,
   type IFCVersion,
 } from "@/lib/ifc-schema"
 import { getEntityContext } from "@/lib/graph-utils"
@@ -1153,80 +1151,21 @@ function ClassificationFields({ node, onChange, ifcVersion, nodes, edges, onConv
   const data = node.data as any // Type assertion for now
   const inRequirements = isInRequirementsSection(node.id, edges)
 
-  // Get entity context from graph connections
-  const entityContext = React.useMemo(() => {
-    return getEntityContext(node.id, nodes, edges)
-  }, [node.id, nodes, edges])
-
-  // Load classification systems based on entity context
-  const [classificationOptions, setClassificationOptions] = useState<SearchableSelectOption[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const loadClassificationSystems = async () => {
-      try {
-        if (!entityContext.entityName) {
-          // Show all classification systems if no entity connected
-          const allSystems = [
-            "Uniclass 2015", "ETIM", "CCI", "OmniClass", "MasterFormat", "Custom"
-          ]
-          const systemOptions: SearchableSelectOption[] = allSystems.map(system => ({
-            value: system,
-            label: system,
-            description: 'Classification system',
-            category: 'All Systems'
-          }))
-          setClassificationOptions(systemOptions)
-        } else {
-          // Show only applicable classification systems for connected entity
-          const entitySystems = await getClassificationSystemsForEntity(entityContext.entityName, ifcVersion)
-          const systemOptions: SearchableSelectOption[] = entitySystems.map(system => ({
-            value: system,
-            label: system,
-            description: 'Applicable to ' + entityContext.entityName,
-            category: 'Entity Specific'
-          }))
-          setClassificationOptions(systemOptions)
-        }
-      } catch (error) {
-        console.warn('Failed to load classification systems:', error)
-        setClassificationOptions([])
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    loadClassificationSystems()
-  }, [entityContext.entityName, ifcVersion])
-
   return (
     <>
       <div className="space-y-2">
         <Label htmlFor="classification-system" className="text-sidebar-foreground">
-          Classification System
-          {loading && <span className="ml-2 text-xs text-muted-foreground">(Loading...)</span>}
-          {entityContext.entityName && (
-            <span className="ml-2 text-xs text-muted-foreground">
-              (Filtered for {entityContext.entityName})
-            </span>
-          )}
+          Classification System <span className="text-muted-foreground font-normal">(Optional)</span>
         </Label>
-        <SearchableSelect
-          options={classificationOptions}
+        <Input
+          id="classification-system"
           value={data.system || ""}
-          onValueChange={(value) => onChange("system", value)}
-          placeholder="Any system (leave empty) — or pick / type a name"
-          searchPlaceholder={entityContext.entityName ? `Search systems for ${entityContext.entityName}...` : "Type any system name (e.g., 'Uniclass 2015', 'OmniClass')..."}
-          emptyText="No matching systems — press Enter to use this name"
-          showCategories={true}
-          maxHeight={300}
-          disabled={loading}
-          allowCustom={true}
-          clearable={true}
-          onCreateOption={(name) => onChange("system", name)}
+          onChange={(e) => onChange("system", e.target.value)}
+          placeholder="Any system — or e.g. Uniclass 2015, OmniClass, ETIM"
+          className="bg-input border-border text-foreground font-mono"
         />
         <p className="text-[11px] text-muted-foreground">
-          Leave empty to match any classification (any system). Type any system name to add a custom one — the IDS schema doesn't constrain the system value.
+          Leave empty to match any classification (any system). Type any string — the IDS schema doesn't constrain the system name.
         </p>
       </div>
       <div className="space-y-2">
@@ -1292,80 +1231,21 @@ function MaterialFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
   const data = node.data as any // Type assertion for now
   const inRequirements = isInRequirementsSection(node.id, edges)
 
-  // Get entity context from graph connections
-  const entityContext = React.useMemo(() => {
-    return getEntityContext(node.id, nodes, edges)
-  }, [node.id, nodes, edges])
-
-  // Load material types based on entity context
-  const [materialOptions, setMaterialOptions] = useState<SearchableSelectOption[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const loadMaterialTypes = async () => {
-      try {
-        if (!entityContext.entityName) {
-          // Show all material types if no entity connected
-          const allMaterials = [
-            "concrete", "steel", "wood", "brick", "glass", "aluminum", "plastic", "composite", "custom"
-          ]
-          const materialOptions: SearchableSelectOption[] = allMaterials.map(material => ({
-            value: material,
-            label: material.charAt(0).toUpperCase() + material.slice(1),
-            description: 'Material type',
-            category: 'All Materials'
-          }))
-          setMaterialOptions(materialOptions)
-        } else {
-          // Show only applicable material types for connected entity
-          const entityMaterials = await getMaterialTypesForEntity(entityContext.entityName, ifcVersion)
-          const materialOptions: SearchableSelectOption[] = entityMaterials.map(material => ({
-            value: material.toLowerCase(),
-            label: material,
-            description: 'Applicable to ' + entityContext.entityName,
-            category: 'Entity Specific'
-          }))
-          setMaterialOptions(materialOptions)
-        }
-      } catch (error) {
-        console.warn('Failed to load material types:', error)
-        setMaterialOptions([])
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    loadMaterialTypes()
-  }, [entityContext.entityName, ifcVersion])
-
   return (
     <>
       <div className="space-y-2">
         <Label htmlFor="material-value" className="text-sidebar-foreground">
           Material Value <span className="text-muted-foreground font-normal">(Optional)</span>
-          {loading && <span className="ml-2 text-xs text-muted-foreground">(Loading...)</span>}
-          {entityContext.entityName && (
-            <span className="ml-2 text-xs text-muted-foreground">
-              (Filtered for {entityContext.entityName})
-            </span>
-          )}
         </Label>
-        <SearchableSelect
-          options={materialOptions}
+        <Input
+          id="material-value"
           value={data.value || ""}
-          onValueChange={(value) => onChange("value", value)}
-          placeholder="Any material (leave empty) — or pick / type a name"
-          searchPlaceholder={entityContext.entityName ? `Search materials for ${entityContext.entityName}...` : "Type any material name (e.g., 'oak', 'rebar steel')..."}
-          emptyText="No matching materials — press Enter to use this name"
-          showCategories={true}
-          maxHeight={300}
-          disabled={loading}
-          allowCustom={true}
-          clearable={true}
-          onCreateOption={(name) => onChange("value", name)}
+          onChange={(e) => onChange("value", e.target.value)}
+          placeholder="Any material — or e.g. concrete, oak, rebar steel"
+          className="bg-input border-border text-foreground font-mono"
         />
         <p className="text-[11px] text-muted-foreground">
-          Leave empty to match any material. Type freely, then press Enter — use <code className="font-mono">[a, b, c]</code> for multiple options.
+          Leave empty to match any material. Multiple acceptable values? Use <code className="font-mono">[a, b, c]</code>.
         </p>
         {onConvertValueToRestriction && (
           <ConvertToRestrictionHint

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -939,11 +939,11 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           id="value"
           value={data.value || ""}
           onChange={(e) => onChange("value", e.target.value)}
-          placeholder={getPlaceholderForDataType(data.dataType)}
+          placeholder={getPlaceholderForDataType(data.dataType) || "Any value — leave empty to match any"}
           className="bg-input border-border text-foreground"
         />
         <p className="text-[11px] text-muted-foreground">
-          For multiple allowed values, type <code className="font-mono">[a, b, c]</code> — you can convert to a Restriction node below.
+          Leave empty to match any value. For multiple allowed values, type <code className="font-mono">[a, b, c]</code> — convertible to a Restriction node below.
         </p>
         {onConvertValueToRestriction && (
           <ConvertToRestrictionHint
@@ -1110,11 +1110,11 @@ function AttributeFields({ node, onChange, ifcVersion, nodes, edges, onConvertVa
           id="attribute-value"
           value={data.value || ""}
           onChange={(e) => onChange("value", e.target.value)}
-          placeholder="e.g., Fire Door — or [Fire Door, Exit Door] for multiple"
+          placeholder="Any value — or e.g. Fire Door / [Fire Door, Exit Door]"
           className="bg-input border-border text-foreground"
         />
         <p className="text-[11px] text-muted-foreground">
-          Need several allowed values? Type them as <code className="font-mono">[a, b, c]</code>.
+          Leave empty to match any value. Need several allowed values? Type them as <code className="font-mono">[a, b, c]</code>.
         </p>
         {onConvertValueToRestriction && (
           <ConvertToRestrictionHint
@@ -1250,11 +1250,11 @@ function ClassificationFields({ node, onChange, ifcVersion, nodes, edges, onConv
           id="classification-value"
           value={data.value || ""}
           onChange={(e) => onChange("value", e.target.value)}
-          placeholder="e.g., Pr_20_70_05_05 — or [Pr_20_70_05_05, Pr_20_70_05_06]"
+          placeholder="Any code — or e.g. Pr_20_70_05_05 / [Pr_20_70_05_05, Pr_20_70_05_06]"
           className="bg-input border-border text-foreground font-mono"
         />
         <p className="text-[11px] text-muted-foreground">
-          Multiple acceptable codes? Use <code className="font-mono">[a, b, c]</code>.
+          Leave empty to match any code under this system. Multiple acceptable codes? Use <code className="font-mono">[a, b, c]</code>.
         </p>
         {onConvertValueToRestriction && (
           <ConvertToRestrictionHint
@@ -1355,7 +1355,7 @@ function MaterialFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
     <>
       <div className="space-y-2">
         <Label htmlFor="material-value" className="text-sidebar-foreground">
-          Material Value
+          Material Value <span className="text-muted-foreground font-normal">(Optional)</span>
           {loading && <span className="ml-2 text-xs text-muted-foreground">(Loading...)</span>}
           {entityContext.entityName && (
             <span className="ml-2 text-xs text-muted-foreground">
@@ -1367,17 +1367,18 @@ function MaterialFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           options={materialOptions}
           value={data.value || ""}
           onValueChange={(value) => onChange("value", value)}
-          placeholder="Search or type a material name..."
+          placeholder="Any material (leave empty) — or pick / type a name"
           searchPlaceholder={entityContext.entityName ? `Search materials for ${entityContext.entityName}...` : "Type any material name (e.g., 'oak', 'rebar steel')..."}
           emptyText="No matching materials — press Enter to use this name"
           showCategories={true}
           maxHeight={300}
           disabled={loading}
           allowCustom={true}
+          clearable={true}
           onCreateOption={(name) => onChange("value", name)}
         />
         <p className="text-[11px] text-muted-foreground">
-          Per the IDS schema, any material name is valid. Type freely, then press Enter — use <code className="font-mono">[a, b, c]</code> for multiple options.
+          Leave empty to match any material. Type freely, then press Enter — use <code className="font-mono">[a, b, c]</code> for multiple options.
         </p>
         {onConvertValueToRestriction && (
           <ConvertToRestrictionHint

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -1211,36 +1211,23 @@ function ClassificationFields({ node, onChange, ifcVersion, nodes, edges, onConv
             </span>
           )}
         </Label>
-        {classificationOptions.length > 0 ? (
-          <SearchableSelect
-            options={classificationOptions}
-            value={data.system || ""}
-            onValueChange={(value) => onChange("system", value)}
-            placeholder="Search classification systems..."
-            searchPlaceholder={entityContext.entityName ? `Search systems for ${entityContext.entityName}...` : "Search classification systems..."}
-            emptyText="No classification systems found"
-            showCategories={true}
-            maxHeight={300}
-            disabled={loading}
-          />
-        ) : (
-          <Select
-            value={data.system || ""}
-            onValueChange={(value) => onChange("system", value)}
-          >
-            <SelectTrigger className="bg-input border-border text-foreground font-mono">
-              <SelectValue placeholder="Select system" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="Uniclass 2015">Uniclass 2015</SelectItem>
-              <SelectItem value="ETIM">ETIM</SelectItem>
-              <SelectItem value="CCI">CCI</SelectItem>
-              <SelectItem value="OmniClass">OmniClass</SelectItem>
-              <SelectItem value="MasterFormat">MasterFormat</SelectItem>
-              <SelectItem value="Custom">Custom</SelectItem>
-            </SelectContent>
-          </Select>
-        )}
+        <SearchableSelect
+          options={classificationOptions}
+          value={data.system || ""}
+          onValueChange={(value) => onChange("system", value)}
+          placeholder="Any system (leave empty) — or pick / type a name"
+          searchPlaceholder={entityContext.entityName ? `Search systems for ${entityContext.entityName}...` : "Type any system name (e.g., 'Uniclass 2015', 'OmniClass')..."}
+          emptyText="No matching systems — press Enter to use this name"
+          showCategories={true}
+          maxHeight={300}
+          disabled={loading}
+          allowCustom={true}
+          clearable={true}
+          onCreateOption={(name) => onChange("system", name)}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Leave empty to match any classification (any system). Type any system name to add a custom one — the IDS schema doesn't constrain the system value.
+        </p>
       </div>
       <div className="space-y-2">
         <Label htmlFor="classification-value" className="text-sidebar-foreground">

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -57,6 +57,24 @@ interface InspectorPanelProps {
   onConvertValueToRestriction?: (facetNodeId: string, fieldName: string, values: string[]) => void
 }
 
+// Module-level cache for inspector schema lookups. Each field component's
+// useEffect runs fresh whenever the selected node changes (because React
+// unmounts the previous field component), and the schema fetchers do real
+// work (or worse, an async network/disk hop). Without this cache, every
+// click on a Property/Attribute/Entity node re-loads the same data and the
+// inspector flickers through "(Loading...)" — perceived as selection lag.
+const inspectorCache = new Map<string, Promise<unknown>>()
+async function cachedLoad<T>(key: string, loader: () => Promise<T>): Promise<T> {
+  const existing = inspectorCache.get(key) as Promise<T> | undefined
+  if (existing) return existing
+  const promise = loader().catch((err) => {
+    inspectorCache.delete(key) // Don't cache failures — retry next time
+    throw err
+  })
+  inspectorCache.set(key, promise)
+  return promise
+}
+
 // Parse a bracketed list like "[R60, R90, R120]" into ["R60", "R90", "R120"].
 // Returns null when the input is not in bracketed form, so callers can keep
 // treating it as a single value.
@@ -553,25 +571,28 @@ function EntityFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node
   const [predefinedTypes, setPredefinedTypes] = useState<string[]>([])
 
   useEffect(() => {
-    const loadEntities = async () => {
-      try {
-        const entities = await getAllEntities(ifcVersion)
-        const entityOptions: SearchableSelectOption[] = entities.map(entity => ({
+    let cancelled = false
+    cachedLoad(`entities:${ifcVersion}`, () => getAllEntities(ifcVersion))
+      .then((entities) => {
+        if (cancelled) return
+        const entityOptions: SearchableSelectOption[] = entities.map((entity) => ({
           value: entity.name,
           label: entity.name,
           description: entity.description,
-          category: entity.category
+          category: entity.category,
         }))
         setAllEntities(entityOptions)
-      } catch (error) {
+      })
+      .catch((error) => {
         console.warn('Failed to load entities from schema:', error)
-        setAllEntities([])
-      } finally {
-        setLoading(false)
-      }
+        if (!cancelled) setAllEntities([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
     }
-
-    loadEntities()
   }, [ifcVersion])
 
   useEffect(() => {
@@ -579,7 +600,15 @@ function EntityFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node
       setPredefinedTypes([])
       return
     }
-    getPredefinedTypesForEntityAsync(data.name, ifcVersion).then(setPredefinedTypes)
+    let cancelled = false
+    cachedLoad(`predefined:${ifcVersion}:${data.name}`, () =>
+      getPredefinedTypesForEntityAsync(data.name, ifcVersion),
+    ).then((types) => {
+      if (!cancelled) setPredefinedTypes(types)
+    })
+    return () => {
+      cancelled = true
+    }
   }, [data.name, ifcVersion])
 
   return (
@@ -675,87 +704,71 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
     return getEntityContext(node.id, nodes, edges)
   }, [node.id, nodes, edges])
 
-  // Load property sets based on entity context
+  // Load property sets based on entity context. The schema lookups are
+  // memoised in `inspectorCache`, so the first selection of a Property node
+  // is async but subsequent selections of the same entity context resolve
+  // synchronously — keeping selection snappy.
   useEffect(() => {
-    const loadPropertySets = async () => {
+    let cancelled = false
+    const run = async () => {
       try {
-        const dataTypes = await getAllSimpleTypes(ifcVersion)
+        const dataTypesPromise = cachedLoad(`simpleTypes:${ifcVersion}`, () =>
+          getAllSimpleTypes(ifcVersion),
+        )
+        const psetsPromise = entityContext.entityName
+          ? cachedLoad(`psetsFor:${ifcVersion}:${entityContext.entityName}`, () =>
+              getPropertySetsForEntityAsync(entityContext.entityName, ifcVersion),
+            )
+          : cachedLoad(`allPsets:${ifcVersion}`, () => getAllPropertySets(ifcVersion))
+        // Warm the property data type cache once per ifcVersion (any property name).
+        const warmPromise = cachedLoad(`dataTypeWarm:${ifcVersion}`, () =>
+          getExpectedDataTypesForPropertyAsync('Reference', ifcVersion),
+        )
+        const [dataTypes, psets] = await Promise.all([dataTypesPromise, psetsPromise, warmPromise])
+        if (cancelled) return
+
         setAllDataTypes(dataTypes)
 
-        // Build property data type cache for accurate recommendations
-        // This needs to be called at least once to populate the cache
-        await getExpectedDataTypesForPropertyAsync('Reference', ifcVersion)
+        // Deduplicate property sets by name (keep first occurrence).
+        const unique = psets.filter(
+          (pset, index, self) => index === self.findIndex((p) => p.name === pset.name),
+        )
 
-        // Get custom property sets
         const customPsets = getCustomPropertySets()
-
-        if (!entityContext.entityName) {
-          // Show ALL property sets if no entity connected
-          const allPsets = await getAllPropertySets(ifcVersion)
-
-          // Deduplicate property sets by name (keep first occurrence)
-          const uniquePsets = allPsets.filter((pset, index, self) =>
-            index === self.findIndex(p => p.name === pset.name)
-          )
-
-          // Merge IFC and custom property sets, avoiding duplicates
-          const ifcOptions: SearchableSelectOption[] = uniquePsets.map(pset => ({
+        const ifcOptions: SearchableSelectOption[] = unique.map((pset) => ({
+          value: pset.name,
+          label: pset.name,
+          description: `${pset.properties?.length || 0} properties`,
+          category: 'IFC Property Sets',
+        }))
+        const customOptions: SearchableSelectOption[] = customPsets
+          .filter((customPset) => !unique.some((ifcPset) => ifcPset.name === customPset.name))
+          .map((pset) => ({
             value: pset.name,
             label: pset.name,
-            description: `${pset.properties?.length || 0} properties`,
-            category: 'IFC Property Sets'
+            description: `${pset.properties.length} custom properties`,
+            category: 'Custom Property Sets',
           }))
 
-          const customOptions: SearchableSelectOption[] = customPsets
-            .filter(customPset => !uniquePsets.some(ifcPset => ifcPset.name === customPset.name))
-            .map(pset => ({
-              value: pset.name,
-              label: pset.name,
-              description: `${pset.properties.length} custom properties`,
-              category: 'Custom Property Sets'
-            }))
-
-          setPropertySetOptions([...ifcOptions, ...customOptions])
-          setLoadedPropertySets([...uniquePsets, ...customPsets.filter(customPset => !uniquePsets.some(ifcPset => ifcPset.name === customPset.name))])
-        } else {
-          // Show only applicable property sets for connected entity
-          const filteredPsets = await getPropertySetsForEntityAsync(entityContext.entityName, ifcVersion)
-
-          // Deduplicate filtered property sets by name (keep first occurrence)
-          const uniqueFilteredPsets = filteredPsets.filter((pset, index, self) =>
-            index === self.findIndex(p => p.name === pset.name)
-          )
-
-          // Custom property sets are always available (entity-agnostic)
-          const ifcOptions: SearchableSelectOption[] = uniqueFilteredPsets.map(pset => ({
-            value: pset.name,
-            label: pset.name,
-            description: `${pset.properties?.length || 0} properties`,
-            category: 'IFC Property Sets'
-          }))
-
-          const customOptions: SearchableSelectOption[] = customPsets
-            .filter(customPset => !uniqueFilteredPsets.some(ifcPset => ifcPset.name === customPset.name))
-            .map(pset => ({
-              value: pset.name,
-              label: pset.name,
-              description: `${pset.properties.length} custom properties`,
-              category: 'Custom Property Sets'
-            }))
-
-          setPropertySetOptions([...ifcOptions, ...customOptions])
-          setLoadedPropertySets([...uniqueFilteredPsets, ...customPsets.filter(customPset => !uniqueFilteredPsets.some(ifcPset => ifcPset.name === customPset.name))])
-        }
+        setPropertySetOptions([...ifcOptions, ...customOptions])
+        setLoadedPropertySets([
+          ...unique,
+          ...customPsets.filter((customPset) => !unique.some((ifcPset) => ifcPset.name === customPset.name)),
+        ])
       } catch (error) {
         console.warn('Failed to load property sets from schema:', error)
-        setPropertySetOptions([])
-        setAllDataTypes([])
+        if (!cancelled) {
+          setPropertySetOptions([])
+          setAllDataTypes([])
+        }
       } finally {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
     }
-
-    loadPropertySets()
+    run()
+    return () => {
+      cancelled = true
+    }
   }, [entityContext.entityName, ifcVersion])
 
   // Get properties for the selected property set
@@ -1025,45 +1038,46 @@ function AttributeFields({ node, onChange, ifcVersion, nodes, edges, onConvertVa
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    const loadAttributes = async () => {
-      try {
-        if (!entityContext.entityName) {
-          // Show common attributes if no entity connected
-          const commonAttributes = [
-            { name: "Name", type: "IFCLABEL", optional: false },
-            { name: "Description", type: "IFCTEXT", optional: true },
-            { name: "Tag", type: "IFCLABEL", optional: true },
-            { name: "GlobalId", type: "IFCGLOBALLYUNIQUEID", optional: false },
-            { name: "ObjectType", type: "IFCLABEL", optional: true },
-            { name: "OwnerHistory", type: "IFCOWNERHISTORY", optional: false }
-          ]
-          const attributeOptions: SearchableSelectOption[] = commonAttributes.map(attr => ({
-            value: attr.name,
-            label: attr.name,
-            description: `${attr.type}${attr.optional ? ' (optional)' : ''}`,
-            category: attr.optional ? 'Optional' : 'Required'
-          }))
-          setAttributeOptions(attributeOptions)
-        } else {
-          // Show only attributes for connected entity
-          const entityAttributes = await getAttributesForEntity(entityContext.entityName, ifcVersion)
-          const attributeOptions: SearchableSelectOption[] = entityAttributes.map(attr => ({
-            value: attr.name,
-            label: attr.name,
-            description: `${attr.type}${attr.optional ? ' (optional)' : ''}`,
-            category: attr.optional ? 'Optional' : 'Required'
-          }))
-          setAttributeOptions(attributeOptions)
-        }
-      } catch (error) {
-        console.warn('Failed to load attributes:', error)
-        setAttributeOptions([])
-      } finally {
-        setLoading(false)
-      }
+    let cancelled = false
+    const commonAttributes = [
+      { name: "Name", type: "IFCLABEL", optional: false },
+      { name: "Description", type: "IFCTEXT", optional: true },
+      { name: "Tag", type: "IFCLABEL", optional: true },
+      { name: "GlobalId", type: "IFCGLOBALLYUNIQUEID", optional: false },
+      { name: "ObjectType", type: "IFCLABEL", optional: true },
+      { name: "OwnerHistory", type: "IFCOWNERHISTORY", optional: false },
+    ]
+    const toOptions = (attrs: Array<{ name: string; type: string; optional: boolean }>) =>
+      attrs.map((attr) => ({
+        value: attr.name,
+        label: attr.name,
+        description: `${attr.type}${attr.optional ? ' (optional)' : ''}`,
+        category: attr.optional ? 'Optional' : 'Required',
+      }))
+
+    if (!entityContext.entityName) {
+      setAttributeOptions(toOptions(commonAttributes))
+      setLoading(false)
+      return
     }
 
-    loadAttributes()
+    const entityName = entityContext.entityName
+    cachedLoad(`attributesFor:${ifcVersion}:${entityName}`, () =>
+      getAttributesForEntity(entityName, ifcVersion),
+    )
+      .then((entityAttributes) => {
+        if (!cancelled) setAttributeOptions(toOptions(entityAttributes))
+      })
+      .catch((error) => {
+        console.warn('Failed to load attributes:', error)
+        if (!cancelled) setAttributeOptions([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [entityContext.entityName, ifcVersion])
 
   return (
@@ -1301,25 +1315,28 @@ function PartOfFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node
   const [entitiesLoading, setEntitiesLoading] = useState(true)
 
   useEffect(() => {
-    const loadEntities = async () => {
-      try {
-        const entities = await getAllEntities(ifcVersion)
-        const entityOptions: SearchableSelectOption[] = entities.map(entity => ({
+    let cancelled = false
+    cachedLoad(`entities:${ifcVersion}`, () => getAllEntities(ifcVersion))
+      .then((entities) => {
+        if (cancelled) return
+        const entityOptions: SearchableSelectOption[] = entities.map((entity) => ({
           value: entity.name,
           label: entity.name,
           description: entity.description,
-          category: entity.category
+          category: entity.category,
         }))
         setAllEntities(entityOptions)
-      } catch (error) {
+      })
+      .catch((error) => {
         console.warn('Failed to load entities from schema:', error)
-        setAllEntities([])
-      } finally {
-        setEntitiesLoading(false)
-      }
+        if (!cancelled) setAllEntities([])
+      })
+      .finally(() => {
+        if (!cancelled) setEntitiesLoading(false)
+      })
+    return () => {
+      cancelled = true
     }
-
-    loadEntities()
   }, [ifcVersion])
 
   // Load spatial relations - always show all 6 valid IDS relations

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -993,9 +993,9 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
   )
 }
 
-function getPlaceholderForDataType(dataType?: string): string {
+function getPlaceholderForDataType(dataType?: string): string | undefined {
   if (!dataType) {
-    return "Enter value..."
+    return undefined
   }
   switch (dataType) {
     case "IFCBOOLEAN":
@@ -1009,7 +1009,7 @@ function getPlaceholderForDataType(dataType?: string): string {
     case "IFCTEXT":
       return "Enter text..."
     default:
-      return "Enter value..."
+      return undefined
   }
 }
 

--- a/components/nodes/attribute-node.tsx
+++ b/components/nodes/attribute-node.tsx
@@ -44,6 +44,11 @@ export function AttributeNode({ data, selected }: NodeProps) {
                                 <span className={facet.text}>Value:</span>
                                 <span className="ml-2 text-foreground">{data.value}</span>
                             </p>
+                        ) : data.hasRestriction ? (
+                            <p className="text-xs text-muted-foreground">
+                                <span className={facet.text}>Value:</span>
+                                <span className="ml-2 text-foreground">restricted (see attached)</span>
+                            </p>
                         ) : (
                             <p className="text-xs italic text-muted-foreground">Any value</p>
                         )}

--- a/components/nodes/attribute-node.tsx
+++ b/components/nodes/attribute-node.tsx
@@ -39,11 +39,13 @@ export function AttributeNode({ data, selected }: NodeProps) {
                 <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">
                         <p className="text-xs text-muted-foreground font-mono">Attribute</p>
-                        {data.value && (
+                        {data.value ? (
                             <p className="text-xs text-muted-foreground">
                                 <span className={facet.text}>Value:</span>
                                 <span className="ml-2 text-foreground">{data.value}</span>
                             </p>
+                        ) : (
+                            <p className="text-xs italic text-muted-foreground">Any value</p>
                         )}
                     </div>
                     {badge && (

--- a/components/nodes/classification-node.tsx
+++ b/components/nodes/classification-node.tsx
@@ -39,11 +39,13 @@ export function ClassificationNode({ data, selected }: NodeProps) {
                 <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">
                         <p className="text-xs text-muted-foreground font-mono">Classification</p>
-                        {data.value && (
+                        {data.value ? (
                             <p className="text-xs text-muted-foreground">
                                 <span className={facet.text}>Code:</span>
                                 <span className="ml-2 text-foreground font-mono">{data.value}</span>
                             </p>
+                        ) : (
+                            <p className="text-xs italic text-muted-foreground">Any code</p>
                         )}
                         {data.uri && (
                             <p className="text-xs text-muted-foreground truncate">

--- a/components/nodes/classification-node.tsx
+++ b/components/nodes/classification-node.tsx
@@ -24,6 +24,7 @@ export function ClassificationNode({ data, selected }: NodeProps) {
     const facet = getFacet("classification")
     const showCardinality = data.isInRequirements === true
     const badge = showCardinality ? getCardinalityBadge(data.cardinality as Cardinality) : null
+    const hasSystem = Boolean(data.system)
 
     return (
         <Card
@@ -34,7 +35,9 @@ export function ClassificationNode({ data, selected }: NodeProps) {
                     <div className={`p-1.5 rounded ${facet.iconBg}`}>
                         <Layers className={`h-4 w-4 ${facet.text}`} />
                     </div>
-                    <h3 className="font-semibold text-sm text-foreground font-mono flex-1 truncate">{data.system}</h3>
+                    <h3 className={`font-semibold text-sm font-mono flex-1 truncate ${hasSystem ? "text-foreground" : "italic text-muted-foreground"}`}>
+                        {hasSystem ? data.system : "Any classification"}
+                    </h3>
                 </div>
                 <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">

--- a/components/nodes/classification-node.tsx
+++ b/components/nodes/classification-node.tsx
@@ -44,6 +44,11 @@ export function ClassificationNode({ data, selected }: NodeProps) {
                                 <span className={facet.text}>Code:</span>
                                 <span className="ml-2 text-foreground font-mono">{data.value}</span>
                             </p>
+                        ) : data.hasRestriction ? (
+                            <p className="text-xs text-muted-foreground">
+                                <span className={facet.text}>Code:</span>
+                                <span className="ml-2 text-foreground">restricted (see attached)</span>
+                            </p>
                         ) : (
                             <p className="text-xs italic text-muted-foreground">Any code</p>
                         )}

--- a/components/nodes/material-node.tsx
+++ b/components/nodes/material-node.tsx
@@ -34,8 +34,8 @@ export function MaterialNode({ data, selected }: NodeProps) {
                     <div className={`p-1.5 rounded ${facet.iconBg}`}>
                         <Package className={`h-4 w-4 ${facet.text}`} />
                     </div>
-                    <h3 className={`font-semibold text-sm font-mono flex-1 truncate ${data.value ? "text-foreground" : "italic text-muted-foreground"}`}>
-                        {data.value || "Any material"}
+                    <h3 className={`font-semibold text-sm font-mono flex-1 truncate ${data.value || data.hasRestriction ? "text-foreground" : "italic text-muted-foreground"}`}>
+                        {data.value || (data.hasRestriction ? "Restricted material" : "Any material")}
                     </h3>
                 </div>
                 <div className="flex items-start justify-between gap-2">

--- a/components/nodes/material-node.tsx
+++ b/components/nodes/material-node.tsx
@@ -34,7 +34,9 @@ export function MaterialNode({ data, selected }: NodeProps) {
                     <div className={`p-1.5 rounded ${facet.iconBg}`}>
                         <Package className={`h-4 w-4 ${facet.text}`} />
                     </div>
-                    <h3 className="font-semibold text-sm text-foreground font-mono flex-1 truncate">{data.value || "Material"}</h3>
+                    <h3 className={`font-semibold text-sm font-mono flex-1 truncate ${data.value ? "text-foreground" : "italic text-muted-foreground"}`}>
+                        {data.value || "Any material"}
+                    </h3>
                 </div>
                 <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">

--- a/components/nodes/property-node.tsx
+++ b/components/nodes/property-node.tsx
@@ -48,7 +48,11 @@ export function PropertyNode({ data, selected }: NodeProps) {
             <p className="text-xs text-muted-foreground font-mono">{data.propertySet}</p>
             <p className="text-xs text-muted-foreground">
               <span className={facet.text}>{data.dataType}</span>
-              {data.value && <span className="ml-2 text-foreground">= {data.value}</span>}
+              {data.value ? (
+                <span className="ml-2 text-foreground">= {data.value}</span>
+              ) : (
+                <span className="ml-2 italic">= any value</span>
+              )}
             </p>
           </div>
           {badge && (

--- a/components/nodes/property-node.tsx
+++ b/components/nodes/property-node.tsx
@@ -50,6 +50,8 @@ export function PropertyNode({ data, selected }: NodeProps) {
               <span className={facet.text}>{data.dataType}</span>
               {data.value ? (
                 <span className="ml-2 text-foreground">= {data.value}</span>
+              ) : data.hasRestriction ? (
+                <span className="ml-2 text-foreground">∈ restricted</span>
               ) : (
                 <span className="ml-2 italic">= any value</span>
               )}

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -43,6 +43,13 @@ export function SpecificationEditor() {
     return saved ? saved.edges : initialEdges
   })
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null)
+  // Pending selection request for newly created nodes. GraphCanvas picks this
+  // up via prop, marks the IDs selected on React Flow's internal node state,
+  // and then calls onPendingSelectionConsumed to clear it. This is how new
+  // nodes (from palette click, template apply, paste, duplicate, restriction
+  // conversion, IDS/JSON import) become the current selection without a
+  // manual click.
+  const [pendingSelectionIds, setPendingSelectionIds] = useState<string[] | null>(null)
   const [ifcVersion, setIfcVersion] = useState<IFCVersion>(() => {
     const saved = loadProjectState()
     return (saved?.ifcVersion as IFCVersion) || "IFC4X3_ADD2"
@@ -90,25 +97,19 @@ export function SpecificationEditor() {
   }, [nodes, edges, ifcVersion])
 
   const updateNodeData = useCallback((nodeId: string, data: any) => {
-    console.log('SpecificationEditor updateNodeData:', { nodeId, data })
     setNodes((nds) => {
-      const updatedNodes = nds.map((node) => {
+      return nds.map((node) => {
         if (node.id === nodeId) {
           const updatedNode = { ...node, data: { ...node.data, ...data } }
-          console.log('Updated node:', updatedNode)
-
-          // Update selectedNode if it's the same node
+          // Update selectedNode if it's the same node so the inspector
+          // reflects the new value without a manual re-click.
           if (selectedNode && selectedNode.id === nodeId) {
             setSelectedNode(updatedNode)
-            console.log('Updated selectedNode:', updatedNode)
           }
-
           return updatedNode
         }
         return node
       })
-      console.log('All nodes after update:', updatedNodes)
-      return updatedNodes
     })
   }, [selectedNode])
 
@@ -123,6 +124,7 @@ export function SpecificationEditor() {
       data: getDefaultNodeData(type, ifcVersion) as NodeData,
     }
     setNodes((nds) => [...nds, newNode])
+    setPendingSelectionIds([newNode.id])
   }, [nodes, edges, ifcVersion, takeSnapshot])
 
   const arrangeAll = useCallback(() => {
@@ -133,9 +135,6 @@ export function SpecificationEditor() {
 
   const applyTemplate = useCallback((template: SpecTemplate) => {
     const timestamp = Date.now()
-
-    console.log(`🚀 Applying template: ${template.name}`)
-    console.log(`📋 Template nodes:`, template.nodes.map(n => ({ type: n.type, data: n.data })))
 
     // Find a clear area for the new template (stack vertically)
     const offset = findTemplateOffset(nodes, { x: 600, y: 150 })
@@ -254,6 +253,11 @@ export function SpecificationEditor() {
     takeSnapshot() // Capture BEFORE applying template
     setNodes((nds) => [...nds, ...nodesToAdd])
     setEdges((eds) => [...eds, ...newEdges])
+
+    // Auto-select the new spec node so the inspector reflects what was just
+    // dropped in. Templates always include a spec in nodesToAdd[0].
+    const newSpec = nodesToAdd.find((n) => n.type === 'spec')
+    if (newSpec) setPendingSelectionIds([newSpec.id])
   }, [nodes, takeSnapshot])
 
   const cloneAsProfile = useCallback(() => {
@@ -347,6 +351,7 @@ export function SpecificationEditor() {
     takeSnapshot() // Capture BEFORE cloning profile
     setNodes((nds) => [...nds, clonedSpec, ...nodesToAdd])
     setEdges((eds) => [...eds, ...clonedEdges])
+    setPendingSelectionIds([clonedSpec.id])
   }, [selectedNode, nodes, edges, takeSnapshot])
 
   const exportCanvas = useCallback(() => {
@@ -436,7 +441,12 @@ export function SpecificationEditor() {
         takeSnapshot()
         setNodes(canvasData.nodes)
         setEdges(canvasData.edges)
-        setSelectedNode(null) // Clear selection
+        setSelectedNode(null)
+
+        // Auto-select the first spec node from the import so the user lands
+        // on something meaningful in the inspector instead of "No Selection".
+        const firstSpec = canvasData.nodes.find((n: GraphNode) => n.type === 'spec')
+        if (firstSpec) setPendingSelectionIds([firstSpec.id])
 
         // Update IFC version if present in metadata
         const detectedVersion = normalizeIfcVersion(canvasData.metadata?.ifcVersion)
@@ -471,6 +481,11 @@ export function SpecificationEditor() {
         setNodes(importedNodes)
         setEdges(importedEdges)
         setSelectedNode(null)
+
+        // Auto-select the first spec from the imported IDS — the user can
+        // start reviewing/editing immediately without hunting for it.
+        const firstSpec = importedNodes.find((n) => n.type === 'spec')
+        if (firstSpec) setPendingSelectionIds([firstSpec.id])
 
         const detectedVersion = normalizeIfcVersion(importedIfcVersion)
         if (detectedVersion) {
@@ -566,7 +581,9 @@ export function SpecificationEditor() {
       setEdges((eds) => [...eds, ...newEdges])
     }
 
-    return newNodes.map((n) => n.id)
+    const newIds = newNodes.map((n) => n.id)
+    setPendingSelectionIds(newIds)
+    return newIds
   }, [takeSnapshot])
 
   // Convert a single facet field carrying multiple values (e.g. "[R60, R90]")
@@ -629,6 +646,10 @@ export function SpecificationEditor() {
       }
       return [...filtered, ...newEdges]
     })
+
+    // Auto-select the new Restriction node so the inspector lands on the
+    // enumeration values for further editing.
+    setPendingSelectionIds([restrictionId])
   }, [nodes, takeSnapshot])
 
   return (
@@ -868,6 +889,8 @@ export function SpecificationEditor() {
                 onEdgesDelete={handleEdgesDelete}
                 onDuplicateNodes={duplicateNodes}
                 onAddNode={addNode}
+                pendingSelectionIds={pendingSelectionIds}
+                onPendingSelectionConsumed={() => setPendingSelectionIds(null)}
                 validationState={validationState}
                 isValidating={isValidating}
                 isValidationDisabled={isValidationDisabled}

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -931,13 +931,13 @@ function getDefaultNodeData(type: string, ifcVersion: IFCVersion = "IFC4X3_ADD2"
       }
     case "classification":
       return {
-        system: "Uniclass 2015",
+        system: "",
         value: "",
         uri: "",
       }
     case "material":
       return {
-        value: "concrete",
+        value: "",
         uri: "",
       }
     case "partOf":

--- a/components/ui/searchable-select.tsx
+++ b/components/ui/searchable-select.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Check, ChevronsUpDown, Search } from "lucide-react"
+import { Check, ChevronsUpDown, Search, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
@@ -40,6 +40,12 @@ interface SearchableSelectProps {
     maxHeight?: number
     allowCustom?: boolean
     onCreateOption?: (value: string) => void
+    /**
+     * Show an inline clear (X) affordance inside the trigger when a value is
+     * selected. Useful for facets where an empty value is meaningful
+     * ("match any") rather than just "not yet filled in".
+     */
+    clearable?: boolean
 }
 
 export function SearchableSelect({
@@ -55,6 +61,7 @@ export function SearchableSelect({
     maxHeight = 300,
     allowCustom = false,
     onCreateOption,
+    clearable = false,
 }: SearchableSelectProps) {
     const [open, setOpen] = React.useState(false)
     const [searchQuery, setSearchQuery] = React.useState("")
@@ -144,7 +151,25 @@ export function SearchableSelect({
                     <span className="truncate">
                         {selectedOption ? selectedOption.label : (value || placeholder)}
                     </span>
-                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    <div className="ml-2 flex shrink-0 items-center gap-1">
+                        {clearable && value && !disabled && (
+                            <span
+                                role="button"
+                                tabIndex={-1}
+                                aria-label="Clear selection"
+                                title="Clear (match any)"
+                                onPointerDown={(e) => {
+                                    e.preventDefault()
+                                    e.stopPropagation()
+                                    onValueChange("")
+                                }}
+                                className="inline-flex h-4 w-4 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+                            >
+                                <X className="h-3 w-3" />
+                            </span>
+                        )}
+                        <ChevronsUpDown className="h-4 w-4 opacity-50" />
+                    </div>
                 </Button>
             </PopoverTrigger>
             <PopoverContent className="w-[400px] p-0" align="start">

--- a/components/ui/searchable-select.tsx
+++ b/components/ui/searchable-select.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Check, ChevronsUpDown, Search, X } from "lucide-react"
+import { Check, ChevronsUpDown, Search } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
@@ -40,12 +40,6 @@ interface SearchableSelectProps {
     maxHeight?: number
     allowCustom?: boolean
     onCreateOption?: (value: string) => void
-    /**
-     * Show an inline clear (X) affordance inside the trigger when a value is
-     * selected. Useful for facets where an empty value is meaningful
-     * ("match any") rather than just "not yet filled in".
-     */
-    clearable?: boolean
 }
 
 export function SearchableSelect({
@@ -61,7 +55,6 @@ export function SearchableSelect({
     maxHeight = 300,
     allowCustom = false,
     onCreateOption,
-    clearable = false,
 }: SearchableSelectProps) {
     const [open, setOpen] = React.useState(false)
     const [searchQuery, setSearchQuery] = React.useState("")
@@ -141,14 +134,6 @@ export function SearchableSelect({
                     variant="outline"
                     role="combobox"
                     aria-expanded={open}
-                    onKeyDown={(e) => {
-                        if (!clearable || !value || disabled) return
-                        if (e.key === "Backspace" || e.key === "Delete") {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            onValueChange("")
-                        }
-                    }}
                     className={cn(
                         "w-full justify-between font-mono text-left",
                         !selectedOption && !value && "text-muted-foreground",
@@ -159,25 +144,7 @@ export function SearchableSelect({
                     <span className="truncate">
                         {selectedOption ? selectedOption.label : (value || placeholder)}
                     </span>
-                    <div className="ml-2 flex shrink-0 items-center gap-1">
-                        {clearable && value && !disabled && (
-                            <span
-                                role="button"
-                                tabIndex={-1}
-                                aria-label="Clear selection"
-                                title="Clear (match any)"
-                                onPointerDown={(e) => {
-                                    e.preventDefault()
-                                    e.stopPropagation()
-                                    onValueChange("")
-                                }}
-                                className="inline-flex h-4 w-4 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-                            >
-                                <X className="h-3 w-3" />
-                            </span>
-                        )}
-                        <ChevronsUpDown className="h-4 w-4 opacity-50" />
-                    </div>
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                 </Button>
             </PopoverTrigger>
             <PopoverContent className="w-[400px] p-0" align="start">

--- a/components/ui/searchable-select.tsx
+++ b/components/ui/searchable-select.tsx
@@ -141,6 +141,14 @@ export function SearchableSelect({
                     variant="outline"
                     role="combobox"
                     aria-expanded={open}
+                    onKeyDown={(e) => {
+                        if (!clearable || !value || disabled) return
+                        if (e.key === "Backspace" || e.key === "Delete") {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            onValueChange("")
+                        }
+                    }}
                     className={cn(
                         "w-full justify-between font-mono text-left",
                         !selectedOption && !value && "text-muted-foreground",

--- a/lib/graph-types.ts
+++ b/lib/graph-types.ts
@@ -77,7 +77,7 @@ export interface ClassificationNodeData {
 }
 
 export interface MaterialNodeData {
-  value: string
+  value?: string  // Optional - empty value means "match any material" (XSD-valid omission of <value>)
   uri?: string
   cardinality?: Cardinality  // Cardinality for requirement facets (not used in applicability)
   instructions?: string  // Instructions attribute for requirement materials (optional)

--- a/lib/ids-client-validation.ts
+++ b/lib/ids-client-validation.ts
@@ -109,19 +109,9 @@ export async function validateGraphClientSide(
         }
     }
 
-    // Validate classification nodes
-    const classificationNodes = nodes.filter(node => node.type === 'classification')
-    for (const node of classificationNodes) {
-        const data = node.data as any
-        if (!data.system) {
-            issues.push({
-                severity: 'warning',
-                message: 'Classification node is missing system',
-                nodeId: node.id,
-                nodeType: 'classification',
-            })
-        }
-    }
+    // Note: an empty classification system is intentional — it means
+    // "match any classification (any system)" and is emitted as an XSD-valid
+    // pattern restriction `.+` by the XML converter. No warning needed.
 
     // Validate that specifications have applicability
     for (const specNode of specNodes) {

--- a/lib/ids-xml-converter.ts
+++ b/lib/ids-xml-converter.ts
@@ -446,8 +446,18 @@ function buildClassificationFacet(node: GraphNode, parent: any, cardinality?: st
     idsSimple(cls, "ids:value", data.value)
   }
 
-  // System must come after value per IDS XSD schema
-  idsSimple(cls, "ids:system", data.system)
+  // System must come after value per IDS XSD schema.
+  // The system element is XSD-required (minOccurs="1"), so we can't omit it
+  // when the user wants "match any classification". Emit a pattern restriction
+  // that matches any non-empty string — this is unambiguously "any system"
+  // (an empty <simpleValue/> would be a literal empty-string match).
+  if (data.system) {
+    idsSimple(cls, "ids:system", data.system)
+  } else {
+    const sysEl = cls.ele("ids:system")
+    const sysRestriction = sysEl.ele("xs:restriction", { base: "xs:string" })
+    sysRestriction.ele("xs:pattern", { value: ".+" })
+  }
 }
 
 function buildMaterialFacet(node: GraphNode, parent: any, cardinality?: string, instructions?: string, edges?: GraphEdge[], nodes?: GraphNode[]) {


### PR DESCRIPTION
## Summary

Property, attribute, and classification already let you leave the value field empty and emit no `<value>` child — which the IDS XSD treats as an existence-only / "match any" check. Material was the odd one out: required-typed value, no clear affordance on the `SearchableSelect`, and the node title fell back to a generic "Material" when empty (indistinguishable from the type label).

This makes the same empty-equals-wildcard behavior uniform across all four value-bearing facets, without adding a flag or any new data model.

- `MaterialNodeData.value` is now optional.
- `SearchableSelect` gets an opt-in `clearable` prop (default off) that renders an inline X inside the trigger; only material wires it up for now.
- All four facet inspectors say "Leave empty to match any …" in the helper text, and the placeholder leads with "Any …" instead of an example value.
- Material / classification / attribute / property nodes render an italic muted "Any material / Any code / Any value / = any value" when the value is empty.

No converter or parser changes — the existing "emit `<value>` only if truthy" logic already produces XSD-valid IDS for the empty case (confirmed against the IDS 1.0 schema: `<xs:element name="value" type="ids:idsValue" minOccurs="0"/>` on every value-bearing facet type).

## Test plan

- [x] `npm run build` succeeds (16 static pages prerendered)
- [x] Dev server returns 200 with no runtime errors
- [ ] On a material node: click the X next to the value → field empties, node title becomes "Any material" in italics, exported IDS contains `<material/>` with no `<value>`
- [ ] On a classification node: clear the code → node shows "Any code", export contains classification with `<system>` only, no `<value>`
- [ ] On property / attribute: same — empty value → "= any value" / "Any value" hint, no `<value>` element in XML
- [ ] Re-import the exported IDS → wildcard nodes come back empty (parser already handles missing `<value>` correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ids-flow/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Facet fields (Value, Classification System, Material Value) are optional—leave empty to match any value
  * Classification System and Material Value switched to simplified free-text inputs
  * Created nodes can be auto-selected after creation (improved selection flow)

* **Bug Fixes / UX**
  * Reduced schema-loading flicker via caching and improved empty/error handling
  * Node views better reflect restricted vs. any/missing values with clearer placeholders and helper text

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ids-flow/pull/39)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->