### PR TITLE
Docs sidebar search: match content, not just titles

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,16 +1,18 @@
 import { DocsSidebar } from "@/components/docs/docs-sidebar";
 import { MobileDocsNav } from "@/components/docs/mobile-docs-nav";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { buildDocsSearchIndex } from "@/lib/docs-search";
 
-export default function DocsLayout({
+export default async function DocsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const searchIndex = await buildDocsSearchIndex();
   return (
     <div className="flex min-h-screen">
       {/* Sidebar Navigation - Desktop */}
-      <DocsSidebar />
+      <DocsSidebar searchIndex={searchIndex} />
 
       {/* Main Content Area */}
       <div className="flex-1 flex flex-col">
@@ -18,7 +20,7 @@ export default function DocsLayout({
         <header className="sticky top-0 z-[90] border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur-sm">
           <div className="flex items-center justify-between px-4 md:px-8 py-4">
             <div className="flex items-center gap-4">
-              <MobileDocsNav />
+              <MobileDocsNav searchIndex={searchIndex} />
               <div>
                 <h1 className="text-lg md:text-xl font-bold text-slate-900 dark:text-slate-100">
                   IDSedit Documentation

--- a/components/docs/docs-search-utils.ts
+++ b/components/docs/docs-search-utils.ts
@@ -1,0 +1,73 @@
+import type { DocsSearchEntry } from "@/lib/docs-search";
+
+export type DocsSearchMatch = {
+  entry: DocsSearchEntry;
+  /** Snippet of content around the match, only set when matched in content. */
+  snippet?: string;
+};
+
+export type DocsSearchSectionResult = {
+  section: string;
+  matches: DocsSearchMatch[];
+};
+
+/**
+ * Simple case-insensitive substring search across title and stripped content.
+ * Section name is also searched so typing the section ("Using the Editor")
+ * surfaces every page inside it.
+ *
+ * Returns one bucket per section in the order they first appear in the index,
+ * so the rendered results follow the same top-to-bottom layout as the unfiltered
+ * sidebar.
+ */
+export function searchDocs(
+  query: string,
+  index: DocsSearchEntry[]
+): DocsSearchSectionResult[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  const order: string[] = [];
+  const bySection = new Map<string, DocsSearchMatch[]>();
+
+  for (const entry of index) {
+    const lowerTitle = entry.title.toLowerCase();
+    const lowerSection = entry.section.toLowerCase();
+    const lowerContent = entry.content.toLowerCase();
+    const titleMatch = lowerTitle.includes(q);
+    const sectionMatch = lowerSection.includes(q);
+    const contentMatch = lowerContent.includes(q);
+    if (!titleMatch && !sectionMatch && !contentMatch) continue;
+
+    const snippet =
+      contentMatch && !titleMatch ? makeSnippet(entry.content, q) : undefined;
+
+    if (!bySection.has(entry.section)) {
+      bySection.set(entry.section, []);
+      order.push(entry.section);
+    }
+    bySection.get(entry.section)!.push({ entry, snippet });
+  }
+
+  return order.map((section) => ({
+    section,
+    matches: bySection.get(section)!,
+  }));
+}
+
+const SNIPPET_LENGTH = 140;
+
+function makeSnippet(content: string, lowerQuery: string): string {
+  const lower = content.toLowerCase();
+  const idx = lower.indexOf(lowerQuery);
+  if (idx === -1) {
+    return content.slice(0, SNIPPET_LENGTH) + (content.length > SNIPPET_LENGTH ? "…" : "");
+  }
+  // Center the snippet around the match, biased to keep it readable.
+  const window = SNIPPET_LENGTH;
+  const start = Math.max(0, idx - Math.floor(window / 3));
+  const end = Math.min(content.length, start + window);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < content.length ? "…" : "";
+  return prefix + content.slice(start, end) + suffix;
+}

--- a/components/docs/docs-search-utils.ts
+++ b/components/docs/docs-search-utils.ts
@@ -21,14 +21,16 @@ export type DocsSearchPageResult = {
 /**
  * Build the deep-link URL for a search hit. We always carry the query along
  * in `?q=...` so the destination page can highlight the term, and we point
- * the fragment at the section slug so the browser scrolls there.
+ * the fragment at the section slug so the browser scrolls there. Falls back
+ * to `&` if the pageHref already has a query string.
  */
 export function buildHitHref(
   pageHref: string,
   hit: DocsSearchHit,
   query: string,
 ): string {
-  const q = `?q=${encodeURIComponent(query)}`;
+  const sep = pageHref.includes("?") ? "&" : "?";
+  const q = `${sep}q=${encodeURIComponent(query)}`;
   const frag = hit.slug ? `#${hit.slug}` : "";
   return `${pageHref}${q}${frag}`;
 }
@@ -65,18 +67,23 @@ export function searchDocs(
       });
       pageOrder.push(entry.href);
     }
-    byHref.get(entry.href)!.hits.push({
-      slug: entry.slug,
-      heading: entry.heading,
-      snippet: inContent ? makeSnippet(entry.content, q) : undefined,
-      headingMatch: inHeading,
-    });
-  }
 
-  // When the only reason a page matched is the section/title (no heading,
-  // no content hit), we still want a top-level entry pointing at the page.
-  // The first chunk already covers that case because it carries the full
-  // heading-less body, so no extra work needed here.
+    const page = byHref.get(entry.href)!;
+    if (inHeading || inContent) {
+      // Real chunk-level hit: link straight to the heading.
+      page.hits.push({
+        slug: entry.slug,
+        heading: entry.heading,
+        snippet: inContent ? makeSnippet(entry.content, q) : undefined,
+        headingMatch: inHeading,
+      });
+    } else if (page.hits.length === 0) {
+      // Section name or page title matched, but this chunk's body didn't.
+      // Add a single page-top fallback so the page appears in results once
+      // — without duplicating it for every chunk on the page.
+      page.hits.push({ slug: "", heading: "", headingMatch: false });
+    }
+  }
 
   return pageOrder.map((href) => byHref.get(href)!);
 }

--- a/components/docs/docs-search-utils.ts
+++ b/components/docs/docs-search-utils.ts
@@ -1,58 +1,84 @@
 import type { DocsSearchEntry } from "@/lib/docs-search";
 
-export type DocsSearchMatch = {
-  entry: DocsSearchEntry;
-  /** Snippet of content around the match, only set when matched in content. */
+export type DocsSearchHit = {
+  /** Slug of the matched section; empty for the page-top chunk. */
+  slug: string;
+  /** Heading text; empty for the page-top chunk. */
+  heading: string;
+  /** Snippet of body content around the match, when matched in body only. */
   snippet?: string;
+  /** True when the search term hit the heading text itself. */
+  headingMatch: boolean;
 };
 
-export type DocsSearchSectionResult = {
+export type DocsSearchPageResult = {
+  href: string;
+  pageTitle: string;
   section: string;
-  matches: DocsSearchMatch[];
+  hits: DocsSearchHit[];
 };
 
 /**
- * Simple case-insensitive substring search across title and stripped content.
- * Section name is also searched so typing the section ("Using the Editor")
- * surfaces every page inside it.
- *
- * Returns one bucket per section in the order they first appear in the index,
- * so the rendered results follow the same top-to-bottom layout as the unfiltered
- * sidebar.
+ * Build the deep-link URL for a search hit. We always carry the query along
+ * in `?q=...` so the destination page can highlight the term, and we point
+ * the fragment at the section slug so the browser scrolls there.
+ */
+export function buildHitHref(
+  pageHref: string,
+  hit: DocsSearchHit,
+  query: string,
+): string {
+  const q = `?q=${encodeURIComponent(query)}`;
+  const frag = hit.slug ? `#${hit.slug}` : "";
+  return `${pageHref}${q}${frag}`;
+}
+
+/**
+ * Substring search across heading + content, returning one or more hits per
+ * page (grouped so the UI can show "Page Title › Section heading" entries).
+ * Sections within a page keep their original order; pages keep their
+ * docs-config order.
  */
 export function searchDocs(
   query: string,
-  index: DocsSearchEntry[]
-): DocsSearchSectionResult[] {
+  index: DocsSearchEntry[],
+): DocsSearchPageResult[] {
   const q = query.trim().toLowerCase();
   if (!q) return [];
 
-  const order: string[] = [];
-  const bySection = new Map<string, DocsSearchMatch[]>();
+  const pageOrder: string[] = [];
+  const byHref = new Map<string, DocsSearchPageResult>();
 
   for (const entry of index) {
-    const lowerTitle = entry.title.toLowerCase();
-    const lowerSection = entry.section.toLowerCase();
-    const lowerContent = entry.content.toLowerCase();
-    const titleMatch = lowerTitle.includes(q);
-    const sectionMatch = lowerSection.includes(q);
-    const contentMatch = lowerContent.includes(q);
-    if (!titleMatch && !sectionMatch && !contentMatch) continue;
+    const inHeading = entry.heading.toLowerCase().includes(q);
+    const inContent = entry.content.toLowerCase().includes(q);
+    const inSection = entry.section.toLowerCase().includes(q);
+    const inPageTitle = entry.pageTitle.toLowerCase().includes(q);
+    if (!inHeading && !inContent && !inSection && !inPageTitle) continue;
 
-    const snippet =
-      contentMatch && !titleMatch ? makeSnippet(entry.content, q) : undefined;
-
-    if (!bySection.has(entry.section)) {
-      bySection.set(entry.section, []);
-      order.push(entry.section);
+    if (!byHref.has(entry.href)) {
+      byHref.set(entry.href, {
+        href: entry.href,
+        pageTitle: entry.pageTitle,
+        section: entry.section,
+        hits: [],
+      });
+      pageOrder.push(entry.href);
     }
-    bySection.get(entry.section)!.push({ entry, snippet });
+    byHref.get(entry.href)!.hits.push({
+      slug: entry.slug,
+      heading: entry.heading,
+      snippet: inContent ? makeSnippet(entry.content, q) : undefined,
+      headingMatch: inHeading,
+    });
   }
 
-  return order.map((section) => ({
-    section,
-    matches: bySection.get(section)!,
-  }));
+  // When the only reason a page matched is the section/title (no heading,
+  // no content hit), we still want a top-level entry pointing at the page.
+  // The first chunk already covers that case because it carries the full
+  // heading-less body, so no extra work needed here.
+
+  return pageOrder.map((href) => byHref.get(href)!);
 }
 
 const SNIPPET_LENGTH = 140;
@@ -63,7 +89,6 @@ function makeSnippet(content: string, lowerQuery: string): string {
   if (idx === -1) {
     return content.slice(0, SNIPPET_LENGTH) + (content.length > SNIPPET_LENGTH ? "…" : "");
   }
-  // Center the snippet around the match, biased to keep it readable.
   const window = SNIPPET_LENGTH;
   const start = Math.max(0, idx - Math.floor(window / 3));
   const end = Math.min(content.length, start + window);

--- a/components/docs/docs-sidebar.tsx
+++ b/components/docs/docs-sidebar.tsx
@@ -5,10 +5,10 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { docsConfig } from "@/lib/docs-config";
 import type { DocsSearchEntry } from "@/lib/docs-search";
-import { searchDocs } from "@/components/docs/docs-search-utils";
+import { buildHitHref, searchDocs } from "@/components/docs/docs-search-utils";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { BookOpen, Home, Search, X } from "lucide-react";
+import { BookOpen, ChevronRight, Home, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -75,36 +75,48 @@ export function DocsSidebar({ searchIndex }: DocsSidebarProps) {
           <nav className="space-y-6 px-4 py-6 pb-8">
             {isSearching ? (
               results.length > 0 ? (
-                results.map((section) => (
-                  <div key={section.section}>
-                    <h3 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-                      {section.section}
-                    </h3>
-                    <ul className="space-y-1">
-                      {section.matches.map(({ entry, snippet }) => {
-                        const isActive = pathname === entry.href;
-                        return (
-                          <li key={entry.href}>
+                results.map((page) => (
+                  <div key={page.href}>
+                    <div className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                      {page.section}
+                    </div>
+                    <Link
+                      href={buildHitHref(page.href, page.hits[0], trimmed)}
+                      className={cn(
+                        "block px-2 py-1.5 text-sm font-medium rounded-md transition-colors",
+                        pathname === page.href
+                          ? "bg-blue-100 dark:bg-blue-900/30 text-blue-900 dark:text-blue-100"
+                          : "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800"
+                      )}
+                    >
+                      {page.pageTitle}
+                    </Link>
+                    {page.hits.length > 0 && (
+                      <ul className="mt-1 ml-2 space-y-0.5 border-l border-slate-200 dark:border-slate-800">
+                        {page.hits.map((hit, i) => (
+                          <li key={`${hit.slug}-${i}`}>
                             <Link
-                              href={entry.href}
-                              className={cn(
-                                "block px-2 py-1.5 text-sm rounded-md transition-colors",
-                                isActive
-                                  ? "bg-blue-100 dark:bg-blue-900/30 text-blue-900 dark:text-blue-100 font-medium"
-                                  : "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800"
-                              )}
+                              href={buildHitHref(page.href, hit, trimmed)}
+                              className="group block pl-3 pr-2 py-1 text-xs rounded-r-md text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-900 dark:hover:text-slate-100"
                             >
-                              <div className="font-medium">{entry.title}</div>
-                              {snippet ? (
-                                <div className="mt-0.5 text-xs leading-snug text-slate-500 dark:text-slate-400 line-clamp-2">
-                                  {highlight(snippet, trimmed)}
+                              <div className="flex items-center gap-1">
+                                <ChevronRight className="h-3 w-3 flex-shrink-0 opacity-50 group-hover:opacity-100" />
+                                <span className="truncate">
+                                  {hit.heading
+                                    ? highlight(hit.heading, trimmed)
+                                    : "Page top"}
+                                </span>
+                              </div>
+                              {hit.snippet ? (
+                                <div className="mt-0.5 ml-4 leading-snug text-slate-500 dark:text-slate-400 line-clamp-2">
+                                  {highlight(hit.snippet, trimmed)}
                                 </div>
                               ) : null}
                             </Link>
                           </li>
-                        );
-                      })}
-                    </ul>
+                        ))}
+                      </ul>
+                    )}
                   </div>
                 ))
               ) : (

--- a/components/docs/docs-sidebar.tsx
+++ b/components/docs/docs-sidebar.tsx
@@ -1,30 +1,32 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { docsConfig } from "@/lib/docs-config";
+import type { DocsSearchEntry } from "@/lib/docs-search";
+import { searchDocs } from "@/components/docs/docs-search-utils";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { BookOpen, Home, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
-export function DocsSidebar() {
+interface DocsSidebarProps {
+  /** Server-built full-text search index passed down from the docs layout. */
+  searchIndex: DocsSearchEntry[];
+}
+
+export function DocsSidebar({ searchIndex }: DocsSidebarProps) {
   const pathname = usePathname();
   const [searchQuery, setSearchQuery] = useState("");
 
-  // Filter docs based on search query
-  const filteredConfig = searchQuery
-    ? docsConfig
-        .map((section) => ({
-          ...section,
-          items: section.items.filter((item) =>
-            item.title.toLowerCase().includes(searchQuery.toLowerCase())
-          ),
-        }))
-        .filter((section) => section.items.length > 0)
-    : docsConfig;
+  const trimmed = searchQuery.trim();
+  const isSearching = trimmed.length > 0;
+  const results = useMemo(
+    () => (isSearching ? searchDocs(trimmed, searchIndex) : []),
+    [trimmed, searchIndex, isSearching]
+  );
 
   return (
     <aside className="hidden md:block w-64 border-r border-slate-200 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50">
@@ -71,8 +73,47 @@ export function DocsSidebar() {
         {/* Navigation */}
         <ScrollArea className="flex-1 min-h-0">
           <nav className="space-y-6 px-4 py-6 pb-8">
-            {filteredConfig.length > 0 ? (
-              filteredConfig.map((section) => (
+            {isSearching ? (
+              results.length > 0 ? (
+                results.map((section) => (
+                  <div key={section.section}>
+                    <h3 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                      {section.section}
+                    </h3>
+                    <ul className="space-y-1">
+                      {section.matches.map(({ entry, snippet }) => {
+                        const isActive = pathname === entry.href;
+                        return (
+                          <li key={entry.href}>
+                            <Link
+                              href={entry.href}
+                              className={cn(
+                                "block px-2 py-1.5 text-sm rounded-md transition-colors",
+                                isActive
+                                  ? "bg-blue-100 dark:bg-blue-900/30 text-blue-900 dark:text-blue-100 font-medium"
+                                  : "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800"
+                              )}
+                            >
+                              <div className="font-medium">{entry.title}</div>
+                              {snippet ? (
+                                <div className="mt-0.5 text-xs leading-snug text-slate-500 dark:text-slate-400 line-clamp-2">
+                                  {highlight(snippet, trimmed)}
+                                </div>
+                              ) : null}
+                            </Link>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-slate-500 dark:text-slate-400 px-2">
+                  No results found for &quot;{trimmed}&quot;
+                </p>
+              )
+            ) : (
+              docsConfig.map((section) => (
                 <div key={section.title}>
                   <h3 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
                     {section.title}
@@ -99,10 +140,6 @@ export function DocsSidebar() {
                   </ul>
                 </div>
               ))
-            ) : (
-              <p className="text-sm text-slate-500 dark:text-slate-400 px-2">
-                No results found for &quot;{searchQuery}&quot;
-              </p>
             )}
           </nav>
         </ScrollArea>
@@ -134,4 +171,35 @@ export function DocsSidebar() {
       </div>
     </aside>
   );
+}
+
+/**
+ * Wrap occurrences of the query in <mark> for the snippet preview.
+ * Case-insensitive, preserves original casing in the snippet.
+ */
+function highlight(text: string, query: string): React.ReactNode {
+  if (!query) return text;
+  const parts: React.ReactNode[] = [];
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+  let i = 0;
+  let cursor = 0;
+  while (cursor < text.length) {
+    const idx = lower.indexOf(q, cursor);
+    if (idx === -1) {
+      parts.push(text.slice(cursor));
+      break;
+    }
+    if (idx > cursor) parts.push(text.slice(cursor, idx));
+    parts.push(
+      <mark
+        key={i++}
+        className="bg-yellow-200/70 dark:bg-yellow-500/30 text-slate-900 dark:text-slate-100 rounded-sm px-0.5"
+      >
+        {text.slice(idx, idx + q.length)}
+      </mark>
+    );
+    cursor = idx + q.length;
+  }
+  return <>{parts}</>;
 }

--- a/components/docs/markdown-content.tsx
+++ b/components/docs/markdown-content.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Suspense, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -13,8 +15,22 @@ interface MarkdownContentProps {
 }
 
 export function MarkdownContent({ content }: MarkdownContentProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
   return (
-    <div className="prose prose-slate dark:prose-invert max-w-none">
+    <div
+      ref={containerRef}
+      className="prose prose-slate dark:prose-invert max-w-none [&_mark.docs-hit]:bg-yellow-200/80 dark:[&_mark.docs-hit]:bg-yellow-500/30 [&_mark.docs-hit]:text-slate-900 dark:[&_mark.docs-hit]:text-slate-100 [&_mark.docs-hit]:rounded-sm [&_mark.docs-hit]:px-0.5"
+    >
+      {/*
+        useSearchParams() forces the closest segment to bail out of static
+        prerendering, so we tuck it behind a Suspense boundary that renders
+        nothing until hydration. The page itself can still be statically
+        prerendered; only the highlighter runs on the client.
+      */}
+      <Suspense fallback={null}>
+        <SearchHighlighter containerRef={containerRef} content={content} />
+      </Suspense>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw, rehypeSlug, rehypeHighlight]}
@@ -164,4 +180,98 @@ export function MarkdownContent({ content }: MarkdownContentProps) {
       </ReactMarkdown>
     </div>
   );
+}
+
+// ---------- Search-term highlighting (in-place, post-render) ----------
+
+const HIGHLIGHT_CLASS = "docs-hit";
+// Avoid touching inline elements that would corrupt visually (code samples
+// keep their syntax highlighting; pre/code spans are skipped). Headings are
+// included so the destination anchor flashes the term visibly.
+const SKIP_SELECTOR = "pre, code, mark, script, style";
+
+/**
+ * Reads `?q=` from the URL and wraps matches in the prose container in
+ * <mark.docs-hit>. Tucked behind Suspense in the parent so useSearchParams
+ * doesn't bail the page out of static prerendering.
+ */
+function SearchHighlighter({
+  containerRef,
+  content,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  content: string;
+}) {
+  const searchParams = useSearchParams();
+  const query = searchParams.get("q")?.trim() ?? "";
+
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+    clearHighlights(root);
+    if (query.length > 0) highlightTextNodes(root, query);
+    return () => {
+      // On unmount or query change, strip any marks we added so subsequent
+      // navigations don't leave stale highlights from the previous page.
+      if (root) clearHighlights(root);
+    };
+  }, [query, content, containerRef]);
+
+  return null;
+}
+
+function clearHighlights(root: HTMLElement) {
+  const marks = root.querySelectorAll<HTMLElement>(`mark.${HIGHLIGHT_CLASS}`);
+  marks.forEach((mark) => {
+    const parent = mark.parentNode;
+    if (!parent) return;
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+    parent.removeChild(mark);
+    parent.normalize();
+  });
+}
+
+function highlightTextNodes(root: HTMLElement, query: string) {
+  const q = query.toLowerCase();
+  if (!q) return;
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = node.parentElement;
+      if (!parent) return NodeFilter.FILTER_REJECT;
+      if (parent.closest(SKIP_SELECTOR)) return NodeFilter.FILTER_REJECT;
+      const text = node.nodeValue ?? "";
+      if (!text || !text.toLowerCase().includes(q)) return NodeFilter.FILTER_REJECT;
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+  // Collect first so we don't mutate while iterating.
+  const targets: Text[] = [];
+  let current = walker.nextNode();
+  while (current) {
+    targets.push(current as Text);
+    current = walker.nextNode();
+  }
+
+  for (const textNode of targets) {
+    const text = textNode.nodeValue ?? "";
+    const lower = text.toLowerCase();
+    const frag = document.createDocumentFragment();
+    let cursor = 0;
+    while (cursor < text.length) {
+      const idx = lower.indexOf(q, cursor);
+      if (idx === -1) {
+        frag.appendChild(document.createTextNode(text.slice(cursor)));
+        break;
+      }
+      if (idx > cursor) {
+        frag.appendChild(document.createTextNode(text.slice(cursor, idx)));
+      }
+      const mark = document.createElement("mark");
+      mark.className = HIGHLIGHT_CLASS;
+      mark.textContent = text.slice(idx, idx + q.length);
+      frag.appendChild(mark);
+      cursor = idx + q.length;
+    }
+    textNode.parentNode?.replaceChild(frag, textNode);
+  }
 }

--- a/components/docs/mobile-docs-nav.tsx
+++ b/components/docs/mobile-docs-nav.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { docsConfig } from "@/lib/docs-config";
 import type { DocsSearchEntry } from "@/lib/docs-search";
-import { searchDocs } from "@/components/docs/docs-search-utils";
+import { buildHitHref, searchDocs } from "@/components/docs/docs-search-utils";
 import { cn } from "@/lib/utils";
 import { Menu, X, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -164,36 +164,42 @@ export function MobileDocsNav({ searchIndex }: MobileDocsNavProps) {
             <nav className="px-4 py-6 space-y-6">
               {isSearching ? (
                 results.length > 0 ? (
-                  results.map((section) => (
-                    <div key={section.section}>
-                      <h3 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-                        {section.section}
-                      </h3>
-                      <ul className="space-y-1">
-                        {section.matches.map(({ entry, snippet }) => {
-                          const isActive = pathname === entry.href;
-                          return (
-                            <li key={entry.href}>
-                              <Link
-                                href={entry.href}
-                                onClick={() => setIsOpen(false)}
-                                className={cn(
-                                  "block px-3 py-2.5 text-sm rounded-lg transition-colors",
-                                  isActive
-                                    ? "bg-blue-100 dark:bg-blue-900/30 text-blue-900 dark:text-blue-100 font-medium"
-                                    : "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 active:bg-slate-200 dark:active:bg-slate-700"
-                                )}
-                              >
-                                <div className="font-medium">{entry.title}</div>
-                                {snippet ? (
-                                  <div className="mt-0.5 text-xs leading-snug text-slate-500 dark:text-slate-400 line-clamp-2">
-                                    {snippet}
-                                  </div>
-                                ) : null}
-                              </Link>
-                            </li>
-                          );
-                        })}
+                  results.map((page) => (
+                    <div key={page.href}>
+                      <div className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                        {page.section}
+                      </div>
+                      <Link
+                        href={buildHitHref(page.href, page.hits[0], trimmed)}
+                        onClick={() => setIsOpen(false)}
+                        className={cn(
+                          "block px-3 py-2 text-sm font-medium rounded-md",
+                          pathname === page.href
+                            ? "bg-blue-100 dark:bg-blue-900/30 text-blue-900 dark:text-blue-100"
+                            : "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800"
+                        )}
+                      >
+                        {page.pageTitle}
+                      </Link>
+                      <ul className="mt-1 ml-2 space-y-0.5 border-l border-slate-200 dark:border-slate-800">
+                        {page.hits.map((hit, i) => (
+                          <li key={`${hit.slug}-${i}`}>
+                            <Link
+                              href={buildHitHref(page.href, hit, trimmed)}
+                              onClick={() => setIsOpen(false)}
+                              className="block pl-3 pr-2 py-1.5 text-xs rounded-r-md text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800"
+                            >
+                              <div className="truncate">
+                                {hit.heading || "Page top"}
+                              </div>
+                              {hit.snippet ? (
+                                <div className="mt-0.5 leading-snug text-slate-500 dark:text-slate-400 line-clamp-2">
+                                  {hit.snippet}
+                                </div>
+                              ) : null}
+                            </Link>
+                          </li>
+                        ))}
                       </ul>
                     </div>
                   ))

--- a/components/docs/mobile-docs-nav.tsx
+++ b/components/docs/mobile-docs-nav.tsx
@@ -1,16 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { docsConfig } from "@/lib/docs-config";
+import type { DocsSearchEntry } from "@/lib/docs-search";
+import { searchDocs } from "@/components/docs/docs-search-utils";
 import { cn } from "@/lib/utils";
 import { Menu, X, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
-export function MobileDocsNav() {
+interface MobileDocsNavProps {
+  searchIndex: DocsSearchEntry[];
+}
+
+export function MobileDocsNav({ searchIndex }: MobileDocsNavProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [mounted, setMounted] = useState(false);
@@ -49,17 +55,12 @@ export function MobileDocsNav() {
     }
   }, [isOpen]);
 
-  // Filter docs based on search query
-  const filteredConfig = searchQuery
-    ? docsConfig
-        .map((section) => ({
-          ...section,
-          items: section.items.filter((item) =>
-            item.title.toLowerCase().includes(searchQuery.toLowerCase())
-          ),
-        }))
-        .filter((section) => section.items.length > 0)
-    : docsConfig;
+  const trimmed = searchQuery.trim();
+  const isSearching = trimmed.length > 0;
+  const results = useMemo(
+    () => (isSearching ? searchDocs(trimmed, searchIndex) : []),
+    [trimmed, searchIndex, isSearching]
+  );
 
   const modalContent = isOpen && mounted ? (
     <>
@@ -161,8 +162,48 @@ export function MobileDocsNav() {
             }}
           >
             <nav className="px-4 py-6 space-y-6">
-              {filteredConfig.length > 0 ? (
-                filteredConfig.map((section) => (
+              {isSearching ? (
+                results.length > 0 ? (
+                  results.map((section) => (
+                    <div key={section.section}>
+                      <h3 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                        {section.section}
+                      </h3>
+                      <ul className="space-y-1">
+                        {section.matches.map(({ entry, snippet }) => {
+                          const isActive = pathname === entry.href;
+                          return (
+                            <li key={entry.href}>
+                              <Link
+                                href={entry.href}
+                                onClick={() => setIsOpen(false)}
+                                className={cn(
+                                  "block px-3 py-2.5 text-sm rounded-lg transition-colors",
+                                  isActive
+                                    ? "bg-blue-100 dark:bg-blue-900/30 text-blue-900 dark:text-blue-100 font-medium"
+                                    : "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 active:bg-slate-200 dark:active:bg-slate-700"
+                                )}
+                              >
+                                <div className="font-medium">{entry.title}</div>
+                                {snippet ? (
+                                  <div className="mt-0.5 text-xs leading-snug text-slate-500 dark:text-slate-400 line-clamp-2">
+                                    {snippet}
+                                  </div>
+                                ) : null}
+                              </Link>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-slate-500 dark:text-slate-400 px-2">
+                    No results found for &quot;{trimmed}&quot;
+                  </p>
+                )
+              ) : (
+                docsConfig.map((section) => (
                   <div key={section.title}>
                     <h3 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
                       {section.title}
@@ -190,10 +231,6 @@ export function MobileDocsNav() {
                     </ul>
                   </div>
                 ))
-              ) : (
-                <p className="text-sm text-slate-500 dark:text-slate-400 px-2">
-                  No results found for &quot;{searchQuery}&quot;
-                </p>
               )}
 
               {/* Attribution */}

--- a/lib/docs-config.ts
+++ b/lib/docs-config.ts
@@ -7,6 +7,13 @@ export type DocItem = {
   title: string;
   href: string;
   mdFile?: string; // corresponding markdown file in ids-docs/
+  /**
+   * Plain-text content for pages that don't have a backing .md file (e.g.
+   * Quick Start, which is rendered from inline JSX). Used by the sidebar's
+   * full-text search so these pages surface on content matches, not just
+   * title matches.
+   */
+  searchableText?: string;
 };
 
 export const docsConfig: DocSection[] = [
@@ -21,6 +28,17 @@ export const docsConfig: DocSection[] = [
       {
         title: "Quick Start",
         href: "/docs/quick-start",
+        searchableText: `Quick Start
+IDS buildingSMART standard. Build your first IDS specification in about two minutes.
+Three concepts: Specification, Applicability, Requirements.
+Walkthrough: walls must have a Fire Rating. Add a Specification node. Set name to Wall Fire Rating.
+Add Entity, connect to Applicability. Set Name to IFCWALL.
+Add Property, connect to Requirements. Set PropertySet to Pset_WallCommon and BaseName to FireRating.
+Leave the value empty for a wildcard meaning must exist any value passes.
+Validation pill top-right of the canvas. Export IDS.
+Property data type is optional in IDS but recommended.
+The default canvas already contains a working Walls-FireRating spec.
+IFC entity names are upper case in IDS XML, IFCWALL not IfcWall.`,
       },
     ],
   },

--- a/lib/docs-search.ts
+++ b/lib/docs-search.ts
@@ -1,0 +1,68 @@
+import "server-only";
+import { loadMarkdownFile } from "./docs-loader";
+import { docsConfig } from "./docs-config";
+
+export type DocsSearchEntry = {
+  href: string;
+  title: string;
+  section: string;
+  /** Plain-text content used for matching + snippet extraction. */
+  content: string;
+};
+
+/**
+ * Markdown → plain text. Strips fence blocks, links, headings markers,
+ * inline code, emphasis, and image syntax so the search index and snippet
+ * extraction work on readable prose.
+ */
+function stripMarkdown(md: string): string {
+  return md
+    // Fenced code blocks
+    .replace(/```[\s\S]*?```/g, " ")
+    // Inline code
+    .replace(/`[^`]*`/g, " ")
+    // Images: ![alt](src) → alt
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    // Links: [text](href) → text
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    // Heading markers
+    .replace(/^#{1,6}\s+/gm, "")
+    // Bold / italic markers
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    // HTML tags
+    .replace(/<[^>]+>/g, " ")
+    // Collapse whitespace
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Server-side: read every docs-config entry's content (either the backing
+ * markdown file or its inline `searchableText`) and produce a search index
+ * the sidebar can do full-text matching against. Called from the docs
+ * layout (Server Component) so the result is computed once at request
+ * time and serialised down to the client sidebar as a prop.
+ */
+export async function buildDocsSearchIndex(): Promise<DocsSearchEntry[]> {
+  const entries: DocsSearchEntry[] = [];
+  for (const section of docsConfig) {
+    for (const item of section.items) {
+      let raw = "";
+      if (item.mdFile) {
+        raw = (await loadMarkdownFile(item.mdFile)) || "";
+      } else if (item.searchableText) {
+        raw = item.searchableText;
+      }
+      entries.push({
+        href: item.href,
+        title: item.title,
+        section: section.title,
+        content: stripMarkdown(raw),
+      });
+    }
+  }
+  return entries;
+}

--- a/lib/docs-search.ts
+++ b/lib/docs-search.ts
@@ -25,8 +25,13 @@ export type DocsSearchEntry = {
 /** Markdown → plain text. */
 function stripMarkdown(md: string): string {
   return md
-    .replace(/```[\s\S]*?```/g, " ")
-    .replace(/`[^`]*`/g, " ")
+    // Fenced code: keep the inner content (drop fence + optional lang). IFC
+    // identifiers and XML snippets in the docs commonly live in fenced blocks,
+    // so this preserves them in the search index.
+    .replace(/```\w*\n?([\s\S]*?)```/g, "$1")
+    // Inline code: keep the text. Terms like `Pset_WallCommon` or `IfcBoolean`
+    // appear almost exclusively in inline code spans in the IDS docs.
+    .replace(/`([^`]*)`/g, "$1")
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
     .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
     .replace(/^#{1,6}\s+/gm, "")

--- a/lib/docs-search.ts
+++ b/lib/docs-search.ts
@@ -1,50 +1,91 @@
 import "server-only";
+import GithubSlugger from "github-slugger";
 import { loadMarkdownFile } from "./docs-loader";
 import { docsConfig } from "./docs-config";
 
+/**
+ * One indexable chunk of a documentation page. We split each page into chunks
+ * at `##` / `###` / … headings so a search hit can deep-link to the exact
+ * section instead of dumping the user at the top of the page. The slug
+ * matches what `rehype-slug` (and our `<h2 id="…">` rendering) emits, so the
+ * fragment in `${href}#${slug}` lands on the right heading.
+ */
 export type DocsSearchEntry = {
   href: string;
-  title: string;
+  pageTitle: string;
   section: string;
-  /** Plain-text content used for matching + snippet extraction. */
+  /** Heading text of the chunk; empty string for content before the first heading. */
+  heading: string;
+  /** Slug compatible with rehype-slug. Empty when there's no heading. */
+  slug: string;
+  /** Plain-text content of the chunk, with markdown stripped. */
   content: string;
 };
 
-/**
- * Markdown → plain text. Strips fence blocks, links, headings markers,
- * inline code, emphasis, and image syntax so the search index and snippet
- * extraction work on readable prose.
- */
+/** Markdown → plain text. */
 function stripMarkdown(md: string): string {
   return md
-    // Fenced code blocks
     .replace(/```[\s\S]*?```/g, " ")
-    // Inline code
     .replace(/`[^`]*`/g, " ")
-    // Images: ![alt](src) → alt
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
-    // Links: [text](href) → text
     .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
-    // Heading markers
     .replace(/^#{1,6}\s+/gm, "")
-    // Bold / italic markers
     .replace(/\*\*([^*]+)\*\*/g, "$1")
     .replace(/\*([^*]+)\*/g, "$1")
     .replace(/__([^_]+)__/g, "$1")
     .replace(/_([^_]+)_/g, "$1")
-    // HTML tags
     .replace(/<[^>]+>/g, " ")
-    // Collapse whitespace
     .replace(/\s+/g, " ")
     .trim();
 }
 
 /**
- * Server-side: read every docs-config entry's content (either the backing
- * markdown file or its inline `searchableText`) and produce a search index
- * the sidebar can do full-text matching against. Called from the docs
- * layout (Server Component) so the result is computed once at request
- * time and serialised down to the client sidebar as a prop.
+ * Split a markdown document into one chunk per heading.
+ *
+ * The pre-heading prose (if any) becomes the first chunk with no heading and
+ * no slug — clicking it just lands on the page top. Slugs are generated with
+ * GithubSlugger (the same library rehype-slug uses), and each slugger
+ * instance handles its own duplicate-suffix accounting so two `## Setup`
+ * headings on the same page get `setup` and `setup-1` to match the rendered
+ * DOM.
+ *
+ * Fenced code blocks are skipped while looking for heading lines so we don't
+ * mistake a `#` inside a code sample for a section break.
+ */
+function splitMarkdownIntoChunks(md: string): Array<{ heading: string; slug: string; body: string }> {
+  const lines = md.split(/\r?\n/);
+  const slugger = new GithubSlugger();
+  const chunks: Array<{ heading: string; slug: string; body: string[] }> = [
+    { heading: "", slug: "", body: [] },
+  ];
+  let inFence = false;
+
+  for (const line of lines) {
+    if (line.startsWith("```")) {
+      inFence = !inFence;
+      chunks[chunks.length - 1].body.push(line);
+      continue;
+    }
+    if (!inFence) {
+      const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+      if (match) {
+        const heading = match[2].trim();
+        chunks.push({ heading, slug: slugger.slug(heading), body: [] });
+        continue;
+      }
+    }
+    chunks[chunks.length - 1].body.push(line);
+  }
+
+  return chunks
+    .map((c) => ({ heading: c.heading, slug: c.slug, body: stripMarkdown(c.body.join("\n")) }))
+    .filter((c) => c.heading || c.body.length > 0);
+}
+
+/**
+ * Build the full-text index. Called from the docs layout (Server Component)
+ * so the result is computed at request time and serialised into the client
+ * sidebar as a prop.
  */
 export async function buildDocsSearchIndex(): Promise<DocsSearchEntry[]> {
   const entries: DocsSearchEntry[] = [];
@@ -56,12 +97,19 @@ export async function buildDocsSearchIndex(): Promise<DocsSearchEntry[]> {
       } else if (item.searchableText) {
         raw = item.searchableText;
       }
-      entries.push({
-        href: item.href,
-        title: item.title,
-        section: section.title,
-        content: stripMarkdown(raw),
-      });
+      if (!raw) continue;
+
+      const chunks = splitMarkdownIntoChunks(raw);
+      for (const chunk of chunks) {
+        entries.push({
+          href: item.href,
+          pageTitle: item.title,
+          section: section.title,
+          heading: chunk.heading,
+          slug: chunk.slug,
+          content: chunk.body,
+        });
+      }
     }
   }
   return entries;


### PR DESCRIPTION
## Summary

Typing \"selection\" or \"multi-selection\" in the docs sidebar search returned **No results found** even though the *Editor interactions* page has a whole \"Selecting\" section. The sidebar's filter only looked at \`item.title\`, so anything not in the sidebar label was invisible to search.

This wires the sidebar to a full-text index of every documented page.

## What changed

- **\`lib/docs-search.ts\`** — server-only helper. Walks \`docsConfig\`, loads each item's backing markdown (or the inline \`searchableText\` for pages rendered from JSX, currently Quick Start), strips markdown syntax, returns a flat array of \`{ href, title, section, content }\`.
- **\`app/docs/layout.tsx\`** — Server Component builds the index at render time and passes it down to both \`DocsSidebar\` and \`MobileDocsNav\`.
- **\`components/docs/docs-search-utils.ts\`** — case-insensitive substring search across title + section + content, results grouped by section in original config order. Snippets are extracted around the hit when the match is in body text only.
- **\`DocsSidebar\`** — renders snippets with the search term highlighted in \`<mark>\`. **\`MobileDocsNav\`** uses the same matcher.
- **\`docs-config.ts\`** — adds optional \`searchableText\` for non-markdown pages so Quick Start surfaces on content terms (\"fire rating\", \"validation pill\", \"wildcard\"), not just on the literal title.

## Verified

- \`npm run build\` succeeds, all 15 docs pages prerender.
- Typing \"selection\" against the live dev server returns two matches with highlighted snippets:
  - Getting Started → Introduction
  - Using the Editor → Editor interactions
- Typing \"multi-selection\" returns the Editor interactions match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ids-flow/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-built docs search index powering unified desktop & mobile search.
  * Full-text matching across titles, sections and page content with grouped results, context snippets, and deep-linking to matched sections.
  * Client-side highlighting of search terms inside rendered documentation.

* **Docs**
  * Added plain-text fallback content support for pages without markdown.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ids-flow/pull/42)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->