### PR TITLE
Canvas arrange-mode toggle: stack IDS cards per spec, structured grouped-mode lanes

### DIFF
--- a/components/edges/lane-edge.tsx
+++ b/components/edges/lane-edge.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { BaseEdge, getSmoothStepPath, type EdgeProps } from "@xyflow/react"
+
+/**
+ * Pixels of horizontal gap between adjacent lanes. Wide enough that two
+ * neighbouring trunks are visually distinct at typical zoom levels, narrow
+ * enough that four-five lanes still fit in the gap between a facet column
+ * and the spec card in grouped mode.
+ */
+const LANE_SPACING = 28
+
+/**
+ * Minimum horizontal distance the trunk for lane 0 keeps from the target.
+ * This is the "closest" lane (top-most source in the sort order).
+ */
+const TRUNK_MARGIN = 30
+
+/**
+ * Custom orthogonal edge that routes each connection through its own vertical
+ * "lane" trunk based on a per-edge index supplied via `data.lane`. Lanes are
+ * staggered horizontally so that when multiple facets converge on the same
+ * spec port, each edge gets a distinct visible vertical run instead of all of
+ * them collapsing onto the same bezier curve. The trunk side and direction
+ * are inferred from the source/target X so the same component works whether
+ * the source is left of the target (grouped mode: facets → spec on the left
+ * port) or right of the target (stacked applicability: facets → spec right
+ * port from the right side of the canvas).
+ */
+export function LaneEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+  data,
+}: EdgeProps) {
+  const lane = (data as { lane?: number } | undefined)?.lane ?? 0
+
+  const isSourceLeftOfTarget = sourceX < targetX
+  let centerX: number
+  if (isSourceLeftOfTarget) {
+    // Trunk lives in the gap to the LEFT of the target. Lane 0 hugs the
+    // target; higher lanes stack outward toward the source.
+    centerX = targetX - TRUNK_MARGIN - lane * LANE_SPACING
+    // Don't let the trunk cross past the source — keeps the path from
+    // doubling back on itself when the gap is too narrow for all lanes.
+    centerX = Math.max(centerX, sourceX + 20)
+  } else {
+    centerX = targetX + TRUNK_MARGIN + lane * LANE_SPACING
+    centerX = Math.min(centerX, sourceX - 20)
+  }
+
+  const [path] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    centerX,
+    borderRadius: 8,
+  })
+
+  return <BaseEdge id={id} path={path} style={style} markerEnd={markerEnd} />
+}

--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useEffect, useState, useRef } from "react"
 import { ReactFlow, Background, BackgroundVariant, Controls, MiniMap, useNodesState, useEdgesState, useReactFlow, type Node, type Edge, type Connection, type OnConnect, type OnNodesChange, type OnEdgesChange, NodeChange, EdgeChange } from "@xyflow/react"
 import { Map as MapIcon } from "lucide-react"
 import type { GraphNode, GraphEdge } from "@/lib/graph-types"
+import type { ArrangeMode } from "@/lib/node-layout"
 import { getEntityContext, isInRequirementsSection } from "@/lib/graph-utils"
 import { SpecificationNode } from "./nodes/specification-node"
 import { EntityNode } from "./nodes/entity-node"
@@ -44,6 +45,13 @@ interface GraphCanvasProps {
   isValidating?: boolean
   isValidationDisabled?: boolean
   onValidateNow?: () => void
+  /**
+   * Active arrange mode. Forwarded into spec node data so the spec card
+   * knows which side to attach its applicability/requirements ports to,
+   * and used here to switch edge rendering between bezier (grouped) and
+   * smoothstep (stacked) so the orthogonal routing matches the layout.
+   */
+  arrangeMode?: ArrangeMode
 }
 
 const nodeTypes = {
@@ -58,7 +66,7 @@ const nodeTypes = {
 }
 
 
-export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes, onAddNode, pendingSelectionIds, onPendingSelectionConsumed, validationState, isValidating = false, isValidationDisabled = false, onValidateNow }: GraphCanvasProps) {
+export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes, onAddNode, pendingSelectionIds, onPendingSelectionConsumed, validationState, isValidating = false, isValidationDisabled = false, onValidateNow, arrangeMode = "grouped" }: GraphCanvasProps) {
   const [showMinimap, setShowMinimap] = useState(true)
   const [focusedSpecTargets, setFocusedSpecTargets] = useState<Record<string, 'applicability' | 'requirements'>>({})
   const [focusedFacetColor, setFocusedFacetColor] = useState<string | null>(null)
@@ -117,9 +125,13 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
           entityContext: entityContext.entityName,
           isInRequirements: inRequirements,
           hasRestriction,
+          // Spec node consumes this to decide which side of the card its
+          // applicability/requirements ports attach to. Sending it on every
+          // node is harmless — non-spec nodes simply ignore the field.
+          arrangeMode,
         },
       }
-    }), [nodes, edges]
+    }), [nodes, edges, arrangeMode]
   )
 
   // Add focus state to nodes separately
@@ -142,8 +154,13 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
       source: edge.source,
       target: edge.target,
       targetHandle: edge.targetHandle,
+      // Use orthogonal (smoothstep) routing in stacked mode so the edges
+      // travel up the right gutter as clean right-angle paths instead of
+      // S-curving through the cards. Grouped mode keeps the default
+      // bezier curve which suits its left→right facet→spec flow.
+      type: arrangeMode === "stacked" ? "smoothstep" : "default",
       style: { stroke: "oklch(0.55 0.18 265)", strokeWidth: 2 },
-    })), [edges]
+    })), [edges, arrangeMode]
   )
 
   // Use ReactFlow's built-in state management

--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -14,6 +14,7 @@ import { ClassificationNode } from "./nodes/classification-node"
 import { MaterialNode } from "./nodes/material-node"
 import { PartOfNode } from "./nodes/partof-node"
 import { RestrictionNode } from "./nodes/restriction-node"
+import { LaneEdge } from "./edges/lane-edge"
 import { FACET_COLORS } from "@/lib/facet-colors"
 import { CanvasValidationOverlay } from "./canvas-validation-overlay"
 import type { ValidationState } from "@/lib/use-ids-validation"
@@ -63,6 +64,10 @@ const nodeTypes = {
   material: MaterialNode,
   partOf: PartOfNode,
   restriction: RestrictionNode,
+}
+
+const edgeTypes = {
+  lane: LaneEdge,
 }
 
 
@@ -149,19 +154,53 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
     })), [baseNodes, focusedSpecTargets, focusedFacetColor, focusedSourceNodeId]
   )
 
+  // Assign each edge a lane index within its (target spec, target port) group,
+  // ranked by the source facet's vertical position. Sorting by Y means the
+  // top-most facet always gets lane 0 (the trunk closest to the spec card),
+  // so when several facets converge on the same Applicability / Requirements
+  // port the edges fan out into stacked vertical lanes that don't cross each
+  // other. Recomputing on every nodes/edges change means dropping a facet at
+  // a new Y position auto-resorts the lanes — which is exactly the
+  // "keep them in visible lanes when dropped" behaviour we want in grouped
+  // mode.
+  const laneByEdgeId = useMemo(() => {
+    const groups = new Map<string, GraphEdge[]>()
+    for (const edge of edges) {
+      const key = `${edge.target}|${edge.targetHandle ?? ""}`
+      const bucket = groups.get(key)
+      if (bucket) bucket.push(edge)
+      else groups.set(key, [edge])
+    }
+    const positionsById = new Map(nodes.map((n) => [n.id, n.position]))
+    const lanes: Record<string, number> = {}
+    for (const bucket of groups.values()) {
+      const sorted = [...bucket].sort((a, b) => {
+        const aY = positionsById.get(a.source)?.y ?? 0
+        const bY = positionsById.get(b.source)?.y ?? 0
+        return aY - bY
+      })
+      sorted.forEach((edge, idx) => {
+        lanes[edge.id] = idx
+      })
+    }
+    return lanes
+  }, [edges, nodes])
+
   const initialEdges: Edge[] = useMemo(() =>
     edges.map(edge => ({
       id: edge.id,
       source: edge.source,
       target: edge.target,
       targetHandle: edge.targetHandle,
-      // Use orthogonal (smoothstep) routing in stacked mode so the edges
-      // travel up the right gutter as clean right-angle paths instead of
-      // S-curving through the cards. Grouped mode keeps the default
-      // bezier curve which suits its left→right facet→spec flow.
-      type: arrangeMode === "stacked" ? "smoothstep" : "default",
+      // Grouped mode: route through the LaneEdge so multiple facets converging
+      // on the same port get distinct vertical trunks instead of overlapping
+      // bezier curves. Stacked mode keeps smoothstep — its applicability
+      // (horizontal step) and requirements (U through right gutter) shapes
+      // already separate cleanly without lane offsets.
+      type: arrangeMode === "stacked" ? "smoothstep" : "lane",
+      data: { lane: laneByEdgeId[edge.id] ?? 0 },
       style: { stroke: "oklch(0.55 0.18 265)", strokeWidth: 2 },
-    })), [edges, arrangeMode]
+    })), [edges, arrangeMode, laneByEdgeId]
   )
 
   // Use ReactFlow's built-in state management
@@ -508,6 +547,7 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
         onNodeDragStart={handleNodeDragStart}
         onNodeDragStop={handleNodeDragStop}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         defaultEdgeOptions={{ type: 'default' }}
         connectionLineType={undefined}
         fitView

--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useMemo, useEffect, useState, useRef } from "react"
-import { ReactFlow, Background, BackgroundVariant, Controls, MiniMap, useNodesState, useEdgesState, useReactFlow, type Node, type Edge, type Connection, type OnConnect, type OnNodesChange, type OnEdgesChange, NodeChange, EdgeChange } from "@xyflow/react"
+import { ReactFlow, Background, BackgroundVariant, Controls, MiniMap, useNodesState, useEdgesState, useReactFlow, useUpdateNodeInternals, type Node, type Edge, type Connection, type OnConnect, type OnNodesChange, type OnEdgesChange, NodeChange, EdgeChange } from "@xyflow/react"
 import { Map as MapIcon } from "lucide-react"
 import type { GraphNode, GraphEdge } from "@/lib/graph-types"
 import type { ArrangeMode } from "@/lib/node-layout"
@@ -75,6 +75,7 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
   const [isDragOver, setIsDragOver] = useState(false)
   const reactFlowContainerRef = useRef<HTMLDivElement>(null)
   const reactFlowInstance = useReactFlow()
+  const updateNodeInternals = useUpdateNodeInternals()
 
   const onPaletteDragOver = useCallback((event: React.DragEvent) => {
     if (!event.dataTransfer.types.includes('application/reactflow-node-type')) return
@@ -166,6 +167,25 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
   // Use ReactFlow's built-in state management
   const [reactFlowNodes, setNodes, onNodesChange] = useNodesState(initialNodes)
   const [reactFlowEdges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
+
+  // When the arrange mode flips, the spec card moves its applicability /
+  // requirements handles to the other side and facet nodes flip their source
+  // handle position. ReactFlow caches each node's handle bounds (the geometry
+  // it uses to anchor edge endpoints) and will *not* recompute them just
+  // because we re-rendered the component — so without this call, every edge
+  // visually stays glued to the previous handle location for a beat and the
+  // result is the stub-on-the-wrong-side artefact in the screenshot. Asking
+  // for an update on every node id forces a re-measure on the next frame.
+  useEffect(() => {
+    const ids = nodes.map((n) => n.id)
+    if (ids.length === 0) return
+    // requestAnimationFrame so the DOM has settled with the new Handle props
+    // before ReactFlow measures.
+    const raf = requestAnimationFrame(() => {
+      ids.forEach((id) => updateNodeInternals(id))
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [arrangeMode, nodes, updateNodeInternals])
 
   // Sync ReactFlow state with parent props only when base nodes change (not during selection/focus changes)
   useEffect(() => {

--- a/components/nodes/attribute-node.tsx
+++ b/components/nodes/attribute-node.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { Handle, Position, type NodeProps } from "@xyflow/react"
+import { Handle, type NodeProps } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Database } from "lucide-react"
 import { getFacet } from "@/lib/facet-colors"
 import type { Cardinality } from "@/lib/graph-types"
+import { getFacetSourcePosition } from "./use-source-handle-position"
 
 // Helper function to get cardinality badge styling
 function getCardinalityBadge(cardinality?: Cardinality) {
@@ -60,7 +61,7 @@ export function AttributeNode({ data, selected }: NodeProps) {
                     )}
                 </div>
             </div>
-            <Handle type="source" position={Position.Right} className={facet.handle} />
+            <Handle type="source" position={getFacetSourcePosition(data as any)} className={facet.handle} />
         </Card>
     )
 }

--- a/components/nodes/classification-node.tsx
+++ b/components/nodes/classification-node.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { Handle, Position, type NodeProps } from "@xyflow/react"
+import { Handle, type NodeProps } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Layers } from "lucide-react"
 import { getFacet } from "@/lib/facet-colors"
 import type { Cardinality } from "@/lib/graph-types"
+import { getFacetSourcePosition } from "./use-source-handle-position"
 
 // Helper function to get cardinality badge styling
 function getCardinalityBadge(cardinality?: Cardinality) {
@@ -69,7 +70,7 @@ export function ClassificationNode({ data, selected }: NodeProps) {
                     )}
                 </div>
             </div>
-            <Handle type="source" position={Position.Right} className={facet.handle} />
+            <Handle type="source" position={getFacetSourcePosition(data as any)} className={facet.handle} />
         </Card>
     )
 }

--- a/components/nodes/entity-node.tsx
+++ b/components/nodes/entity-node.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { Handle, Position, type NodeProps } from "@xyflow/react"
+import { Handle, type NodeProps } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Box } from "lucide-react"
 import { getFacet } from "@/lib/facet-colors"
 import type { Cardinality } from "@/lib/graph-types"
+import { getFacetSourcePosition } from "./use-source-handle-position"
 
 // Helper function to get cardinality badge styling
 function getCardinalityBadge(cardinality?: Cardinality) {
@@ -46,7 +47,7 @@ export function EntityNode({ data, selected }: NodeProps) {
           )}
         </div>
       </div>
-      <Handle type="source" position={Position.Right} className={facet.handle} />
+      <Handle type="source" position={getFacetSourcePosition(data as any)} className={facet.handle} />
     </Card>
   )
 }

--- a/components/nodes/material-node.tsx
+++ b/components/nodes/material-node.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { Handle, Position, type NodeProps } from "@xyflow/react"
+import { Handle, type NodeProps } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Package } from "lucide-react"
 import { getFacet } from "@/lib/facet-colors"
 import type { Cardinality } from "@/lib/graph-types"
+import { getFacetSourcePosition } from "./use-source-handle-position"
 
 // Helper function to get cardinality badge styling
 function getCardinalityBadge(cardinality?: Cardinality) {
@@ -55,7 +56,7 @@ export function MaterialNode({ data, selected }: NodeProps) {
                     )}
                 </div>
             </div>
-            <Handle type="source" position={Position.Right} className={facet.handle} />
+            <Handle type="source" position={getFacetSourcePosition(data as any)} className={facet.handle} />
         </Card>
     )
 }

--- a/components/nodes/partof-node.tsx
+++ b/components/nodes/partof-node.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { Handle, Position, type NodeProps } from "@xyflow/react"
+import { Handle, type NodeProps } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { GitBranch } from "lucide-react"
 import { getFacet } from "@/lib/facet-colors"
 import type { Cardinality } from "@/lib/graph-types"
+import { getFacetSourcePosition } from "./use-source-handle-position"
 
 // Helper function to get cardinality badge styling
 function getCardinalityBadge(cardinality?: Cardinality) {
@@ -53,7 +54,7 @@ export function PartOfNode({ data, selected }: NodeProps) {
                     )}
                 </div>
             </div>
-            <Handle type="source" position={Position.Right} className={facet.handle} />
+            <Handle type="source" position={getFacetSourcePosition(data as any)} className={facet.handle} />
         </Card>
     )
 }

--- a/components/nodes/port-label-row.tsx
+++ b/components/nodes/port-label-row.tsx
@@ -9,17 +9,36 @@ interface PortLabelRowProps {
     highlightColor?: string
     handleColor?: string
     highlightSourceId?: string
+    /**
+     * Which side of the card the port handle should attach to.
+     * Defaults to "left" — the original grouped-layout behaviour where
+     * facets sit to the left of the spec card.
+     *
+     * When set to "right" (used by stacked-layout mode), the label aligns
+     * to the right edge of the row and the handle sits on the right side
+     * of the card, so edges from facets stacked below the spec can take a
+     * clean right-side orthogonal path back up to the spec.
+     */
+    side?: "left" | "right"
 }
 
-export function PortLabelRow({ id, label, highlighted = false, highlightColor, handleColor, highlightSourceId }: PortLabelRowProps) {
+export function PortLabelRow({ id, label, highlighted = false, highlightColor, handleColor, highlightSourceId, side = "left" }: PortLabelRowProps) {
+    const isRight = side === "right"
     return (
-        <div className="relative flex items-center" style={highlightColor ? ({ ['--highlight-color' as any]: highlightColor } as React.CSSProperties) : undefined}>
+        <div
+            className={`relative flex items-center ${isRight ? "justify-end" : ""}`}
+            style={highlightColor ? ({ ['--highlight-color' as any]: highlightColor } as React.CSSProperties) : undefined}
+        >
             <Handle
                 type="target"
-                position={Position.Left}
+                position={isRight ? Position.Right : Position.Left}
                 id={id}
                 className={handleColor || "bg-accent"}
-                style={{ position: 'absolute', left: '-20px', top: '50%', transform: 'translateY(-50%)' }}
+                style={
+                    isRight
+                        ? { position: 'absolute', right: '-20px', top: '50%', transform: 'translateY(-50%)' }
+                        : { position: 'absolute', left: '-20px', top: '50%', transform: 'translateY(-50%)' }
+                }
             />
             <span
                 key={highlighted ? `${highlightSourceId}-${highlightColor}` : undefined}

--- a/components/nodes/property-node.tsx
+++ b/components/nodes/property-node.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { Handle, Position, type NodeProps } from "@xyflow/react"
+import { Handle, type NodeProps } from "@xyflow/react"
 import { Card } from "@/components/ui/card"
 import { Tag, Filter } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { getFacet } from "@/lib/facet-colors"
 import type { Cardinality } from "@/lib/graph-types"
+import { getFacetSourcePosition } from "./use-source-handle-position"
 
 // Helper function to get cardinality badge styling
 function getCardinalityBadge(cardinality?: Cardinality) {
@@ -64,7 +65,7 @@ export function PropertyNode({ data, selected }: NodeProps) {
           )}
         </div>
       </div>
-      <Handle type="source" position={Position.Right} className={facet.handle} />
+      <Handle type="source" position={getFacetSourcePosition(data as any)} className={facet.handle} />
     </Card>
   )
 }

--- a/components/nodes/specification-node.tsx
+++ b/components/nodes/specification-node.tsx
@@ -25,8 +25,14 @@ export function SpecificationNode({ data, selected }: NodeProps) {
     highlightTarget?: 'applicability' | 'requirements'
     highlightColor?: string
     highlightSourceId?: string
+    arrangeMode?: 'grouped' | 'stacked'
   }
   const applicabilityBadge = getApplicabilityBadge(nodeData.applicabilityCardinality)
+  // In stacked mode the spec sits above a vertical column of facets, so the
+  // applicability/requirements ports need to attach on the right side of the
+  // card. Edges then route as clean orthogonal U-shapes up the right gutter
+  // instead of S-curving across the card body.
+  const portSide: 'left' | 'right' = nodeData.arrangeMode === 'stacked' ? 'right' : 'left'
 
   return (
     <Card
@@ -61,6 +67,7 @@ export function SpecificationNode({ data, selected }: NodeProps) {
             highlighted={nodeData.highlightTarget === 'applicability'}
             highlightColor={nodeData.highlightColor}
             highlightSourceId={nodeData.highlightSourceId}
+            side={portSide}
           />
           <PortLabelRow
             id="requirements"
@@ -69,6 +76,7 @@ export function SpecificationNode({ data, selected }: NodeProps) {
             highlighted={nodeData.highlightTarget === 'requirements'}
             highlightColor={nodeData.highlightColor}
             highlightSourceId={nodeData.highlightSourceId}
+            side={portSide}
           />
         </div>
       </div>

--- a/components/nodes/use-source-handle-position.ts
+++ b/components/nodes/use-source-handle-position.ts
@@ -1,0 +1,24 @@
+import { Position } from "@xyflow/react"
+
+/**
+ * Pick which side of a facet card its source handle should attach to.
+ *
+ * Default: right side (the original grouped-layout behaviour where facets
+ * sit to the left of the spec card and connect rightwards into it).
+ *
+ * In stacked arrange mode, applicability facets are repositioned to the
+ * right of the spec card and connect leftwards into the spec's right-side
+ * applicability port — so their source handle needs to be on the *left*
+ * for the edge to render as a clean straight line between the two cards.
+ * Requirements facets continue to live below the spec and source from the
+ * right, taking a U-shaped smoothstep path through the right gutter.
+ */
+export function getFacetSourcePosition(data: {
+    arrangeMode?: "grouped" | "stacked"
+    isInRequirements?: boolean
+}): Position {
+    if (data.arrangeMode === "stacked" && data.isInRequirements !== true) {
+        return Position.Left
+    }
+    return Position.Right
+}

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -34,14 +34,18 @@ export function SpecificationEditor() {
     return supported.includes(value as IFCVersion) ? (value as IFCVersion) : undefined
   }, [])
 
-  const [nodes, setNodes] = useState<GraphNode[]>(() => {
-    const saved = loadProjectState()
-    return saved ? saved.nodes : initialNodes
-  })
-  const [edges, setEdges] = useState<GraphEdge[]>(() => {
-    const saved = loadProjectState()
-    return saved ? saved.edges : initialEdges
-  })
+  // IMPORTANT: do *not* read sessionStorage in these initialisers. The
+  // editor is a `"use client"` component but Next.js still server-renders it
+  // on the initial page load; sessionStorage is only available in the
+  // browser, so anything we initialise from it here would differ between the
+  // server-rendered HTML and the first client render and trigger a
+  // hydration mismatch (the arrange-mode toggle button label / title / aria
+  // are the most visible casualties). Instead, mount with the same defaults
+  // the server uses and then rehydrate from sessionStorage in a single
+  // effect below, guarded by `hydrated` so the autosave effect doesn't
+  // overwrite the stored state with the empty defaults in the meantime.
+  const [nodes, setNodes] = useState<GraphNode[]>(initialNodes)
+  const [edges, setEdges] = useState<GraphEdge[]>(initialEdges)
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null)
   // Pending selection request for newly created nodes. GraphCanvas picks this
   // up via prop, marks the IDs selected on React Flow's internal node state,
@@ -50,19 +54,17 @@ export function SpecificationEditor() {
   // conversion, IDS/JSON import) become the current selection without a
   // manual click.
   const [pendingSelectionIds, setPendingSelectionIds] = useState<string[] | null>(null)
-  const [ifcVersion, setIfcVersion] = useState<IFCVersion>(() => {
-    const saved = loadProjectState()
-    return (saved?.ifcVersion as IFCVersion) || "IFC4X3_ADD2"
-  })
+  const [ifcVersion, setIfcVersion] = useState<IFCVersion>("IFC4X3_ADD2")
   // Canvas arrange mode. "grouped" keeps the original two-column layout
   // (facets left, spec right, specs stacked vertically). "stacked" arranges
   // each specification as its own vertical column (spec on top, facets
   // stacked beneath it, specs placed side-by-side). The mode is persisted in
   // sessionStorage alongside the rest of the project state.
-  const [arrangeMode, setArrangeMode] = useState<ArrangeMode>(() => {
-    const saved = loadProjectState()
-    return saved?.arrangeMode ?? "grouped"
-  })
+  const [arrangeMode, setArrangeMode] = useState<ArrangeMode>("grouped")
+  // Flips to true after the first client-side mount once we've had a chance
+  // to read sessionStorage. Used to gate the autosave effect so the freshly
+  // mounted defaults can't clobber a saved project on the way in.
+  const [hydrated, setHydrated] = useState(false)
   const [jsonFileInputRef, setJsonFileInputRef] = useState<HTMLInputElement | null>(null)
   const [idsFileInputRef, setIdsFileInputRef] = useState<HTMLInputElement | null>(null)
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
@@ -100,10 +102,35 @@ export function SpecificationEditor() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [undo, redo])
 
-  // Persist project state to sessionStorage so it survives navigation (e.g. to /docs and back)
+  // Rehydrate from sessionStorage exactly once after first client mount.
+  // Doing this in an effect (rather than in the useState initialisers) keeps
+  // the server-rendered HTML and the first client render identical, which is
+  // what avoids the hydration mismatch on the arrange-mode toggle button and
+  // anything else whose label/aria depends on the persisted state. After
+  // applying the saved values we flip `hydrated` so the autosave effect can
+  // start syncing further changes back to sessionStorage.
   useEffect(() => {
+    const saved = loadProjectState()
+    if (saved) {
+      setNodes(saved.nodes)
+      setEdges(saved.edges)
+      const v = normalizeIfcVersion(saved.ifcVersion)
+      if (v) setIfcVersion(v)
+      if (saved.arrangeMode === "stacked" || saved.arrangeMode === "grouped") {
+        setArrangeMode(saved.arrangeMode)
+      }
+    }
+    setHydrated(true)
+  }, [normalizeIfcVersion])
+
+  // Persist project state to sessionStorage so it survives navigation (e.g.
+  // to /docs and back). Gated on `hydrated` so the initial render with empty
+  // defaults doesn't overwrite a saved project before we've had a chance to
+  // read it back in the effect above.
+  useEffect(() => {
+    if (!hydrated) return
     saveProjectState(nodes, edges, ifcVersion, arrangeMode)
-  }, [nodes, edges, ifcVersion, arrangeMode])
+  }, [hydrated, nodes, edges, ifcVersion, arrangeMode])
 
   const updateNodeData = useCallback((nodeId: string, data: any) => {
     setNodes((nds) => {

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -939,6 +939,7 @@ export function SpecificationEditor() {
                 isValidating={isValidating}
                 isValidationDisabled={isValidationDisabled}
                 onValidateNow={validateNow}
+                arrangeMode={arrangeMode}
               />
             </Panel>
             <CustomPanelResizeHandle />

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -10,7 +10,7 @@ import { SchemaSwitcher } from "./schema-switcher"
 import { TemplatesDialog } from "./templates-dialog"
 import { IdsExportDialog } from "./ids-export-dialog"
 import { Button } from "./ui/button"
-import { Copy, Download, Upload, FileText, Layout, RotateCcw, RotateCw, HelpCircle, MoreVertical } from "lucide-react"
+import { Copy, Download, Upload, FileText, Layout, LayoutGrid, RotateCcw, RotateCw, HelpCircle, MoreVertical } from "lucide-react"
 import { ThemeToggle } from "@/components/theme-toggle"
 import Link from "next/link"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator } from "./ui/dropdown-menu"
@@ -22,7 +22,7 @@ import { initialNodes, initialEdges } from "@/lib/initial-data"
 import { loadProjectState, saveProjectState } from "@/lib/project-session-store"
 import { convertGraphToIdsXml } from "@/lib/ids-xml-converter"
 import { convertIdsXmlToGraph } from "@/lib/ids-xml-parser"
-import { calculateSmartPositionForNewNode, findTemplateOffset, calculateNodePosition, DEFAULT_LAYOUT_CONFIG, relayoutNodes, findExistingNode } from "@/lib/node-layout"
+import { calculateSmartPositionForNewNode, findTemplateOffset, calculateNodePosition, DEFAULT_LAYOUT_CONFIG, relayoutNodes, findExistingNode, type ArrangeMode } from "@/lib/node-layout"
 import { useIdsValidation } from "@/lib/use-ids-validation"
 import { useUndoRedo } from "@/lib/use-undo-redo"
 import { AppFooter } from "./app-footer"
@@ -53,6 +53,15 @@ export function SpecificationEditor() {
   const [ifcVersion, setIfcVersion] = useState<IFCVersion>(() => {
     const saved = loadProjectState()
     return (saved?.ifcVersion as IFCVersion) || "IFC4X3_ADD2"
+  })
+  // Canvas arrange mode. "grouped" keeps the original two-column layout
+  // (facets left, spec right, specs stacked vertically). "stacked" arranges
+  // each specification as its own vertical column (spec on top, facets
+  // stacked beneath it, specs placed side-by-side). The mode is persisted in
+  // sessionStorage alongside the rest of the project state.
+  const [arrangeMode, setArrangeMode] = useState<ArrangeMode>(() => {
+    const saved = loadProjectState()
+    return saved?.arrangeMode ?? "grouped"
   })
   const [jsonFileInputRef, setJsonFileInputRef] = useState<HTMLInputElement | null>(null)
   const [idsFileInputRef, setIdsFileInputRef] = useState<HTMLInputElement | null>(null)
@@ -93,8 +102,8 @@ export function SpecificationEditor() {
 
   // Persist project state to sessionStorage so it survives navigation (e.g. to /docs and back)
   useEffect(() => {
-    saveProjectState(nodes, edges, ifcVersion)
-  }, [nodes, edges, ifcVersion])
+    saveProjectState(nodes, edges, ifcVersion, arrangeMode)
+  }, [nodes, edges, ifcVersion, arrangeMode])
 
   const updateNodeData = useCallback((nodeId: string, data: any) => {
     setNodes((nds) => {
@@ -129,9 +138,19 @@ export function SpecificationEditor() {
 
   const arrangeAll = useCallback(() => {
     takeSnapshot() // Capture BEFORE rearranging
-    const updatedNodes = relayoutNodes(nodes, edges)
+    const updatedNodes = relayoutNodes(nodes, edges, arrangeMode)
     setNodes(updatedNodes)
-  }, [nodes, edges, takeSnapshot])
+  }, [nodes, edges, takeSnapshot, arrangeMode])
+
+  // Flip between grouped/stacked layout and immediately re-arrange so the
+  // user sees the result of the toggle without a second click on "Arrange
+  // All". We snapshot first so the layout flip is itself undoable.
+  const toggleArrangeMode = useCallback(() => {
+    const nextMode: ArrangeMode = arrangeMode === "stacked" ? "grouped" : "stacked"
+    takeSnapshot()
+    setArrangeMode(nextMode)
+    setNodes(relayoutNodes(nodes, edges, nextMode))
+  }, [arrangeMode, nodes, edges, takeSnapshot])
 
   const applyTemplate = useCallback((template: SpecTemplate) => {
     const timestamp = Date.now()
@@ -706,10 +725,31 @@ export function SpecificationEditor() {
               size="sm"
               className="gap-1.5 h-8 px-2.5 bg-card"
               onClick={arrangeAll}
-              title="Auto-arrange all nodes"
+              title={
+                arrangeMode === "stacked"
+                  ? "Auto-arrange — vertical stack per specification"
+                  : "Auto-arrange — grouped facets per specification"
+              }
             >
               <Layout className="h-3.5 w-3.5" />
               <span className="hidden xl:inline">Arrange All</span>
+            </Button>
+            <Button
+              variant={arrangeMode === "stacked" ? "default" : "outline"}
+              size="sm"
+              className="gap-1.5 h-8 px-2.5"
+              onClick={toggleArrangeMode}
+              title={
+                arrangeMode === "stacked"
+                  ? "Stacked layout active — click for grouped layout"
+                  : "Grouped layout active — click to stack cards vertically per specification"
+              }
+              aria-pressed={arrangeMode === "stacked"}
+            >
+              <LayoutGrid className="h-3.5 w-3.5" />
+              <span className="hidden xl:inline">
+                {arrangeMode === "stacked" ? "Stacked" : "Grouped"}
+              </span>
             </Button>
             <Button
               variant="outline"
@@ -815,6 +855,10 @@ export function SpecificationEditor() {
                 <DropdownMenuItem onClick={arrangeAll}>
                   <Layout className="h-4 w-4 mr-2" />
                   Arrange All
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={toggleArrangeMode}>
+                  <LayoutGrid className="h-4 w-4 mr-2" />
+                  {arrangeMode === "stacked" ? "Layout: Stacked" : "Layout: Grouped"}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={cloneAsProfile}

--- a/lib/node-layout.ts
+++ b/lib/node-layout.ts
@@ -34,17 +34,26 @@ export const DEFAULT_LAYOUT_CONFIG: LayoutConfig = {
     nodeHeight: 100,
 }
 
-// Width of one specification column in "stacked" arrange mode. Roughly the
-// spec card width (280px) plus a comfortable horizontal gutter so neighboring
-// columns don't visually collide with restriction nodes that sit to the right.
-const STACKED_COLUMN_WIDTH = 560
-// Vertical pitch between cards within a stacked column. Generous enough that
-// the orthogonal edges in the right-side gutter don't run into one another
-// and every facet card has clear breathing room.
-const STACKED_VERTICAL_SPACING = 190
-// Vertical gap inserted between the applicability and requirements sections.
-const STACKED_SECTION_GAP = 60
-// Horizontal offset of a restriction relative to its parent facet's column.
+// Spec card width — kept in sync with `w-[280px]` on SpecificationNode.
+const SPEC_CARD_WIDTH = 280
+// Horizontal offset between the spec card and its applicability stack on
+// the right. Picks up after the spec card with a small gutter so the
+// connecting edge has clear breathing room and the cards never abut.
+const STACKED_APPLICABILITY_X_OFFSET = SPEC_CARD_WIDTH + 80
+// Vertical offset of the requirements stack below the spec card. Big
+// enough to clear the full spec card (header + description + port rows)
+// and keep the first requirement visually separated from the spec.
+const STACKED_REQUIREMENTS_Y_OFFSET = 260
+// Width of one specification column in "stacked" arrange mode. Has to fit
+// the spec card, the applicability stack to its right, and a restriction
+// column on the far right, all with comfortable horizontal gutters before
+// the next spec column begins.
+const STACKED_COLUMN_WIDTH = 920
+// Vertical pitch between cards within a stacked column. Generous enough
+// that the orthogonal edges in the right-side gutter don't run into one
+// another and every facet card has clear breathing room.
+const STACKED_VERTICAL_SPACING = 170
+// Horizontal offset of a restriction relative to its parent facet.
 const STACKED_RESTRICTION_OFFSET = 280
 
 // Node type priority for ordering within groups
@@ -524,35 +533,43 @@ function relayoutNodesStacked(
         applicabilityFacets.sort(sortByPriority)
         requirementsFacets.sort(sortByPriority)
 
-        // Stack applicability facets directly below the spec.
-        let cursorY = baseY + STACKED_VERTICAL_SPACING
+        // Applicability facets stack to the RIGHT of the spec card. Their
+        // source handle attaches on the LEFT (see getFacetSourcePosition),
+        // so a clean horizontal edge runs from the spec's right-side
+        // applicability port straight into each facet's left handle.
+        const applicabilityX = columnX + STACKED_APPLICABILITY_X_OFFSET
+        let appY = baseY
         applicabilityFacets.forEach(facet => {
-            updatePosition(facet.id, { x: columnX, y: cursorY })
+            updatePosition(facet.id, { x: applicabilityX, y: appY })
             const restriction = restrictionForFacet.get(facet.id)
             if (restriction) {
+                // Park applicability restrictions further to the right of
+                // their facet. The chain is facet -> restriction -> spec;
+                // routing isn't perfectly straight here but stays readable
+                // because both segments stay inside this spec's column.
                 updatePosition(restriction.id, {
-                    x: columnX + STACKED_RESTRICTION_OFFSET,
-                    y: cursorY,
+                    x: applicabilityX + STACKED_RESTRICTION_OFFSET,
+                    y: appY,
                 })
             }
-            cursorY += STACKED_VERTICAL_SPACING
+            appY += STACKED_VERTICAL_SPACING
         })
 
-        // Group gap before requirements, so the two sections read as distinct.
-        if (requirementsFacets.length > 0) {
-            cursorY += STACKED_SECTION_GAP
-        }
-
+        // Requirements facets stack directly BELOW the spec card. Their
+        // source handle stays on the RIGHT, so each edge takes a clean
+        // smoothstep U-shape from the spec's right-side requirements port
+        // down the right gutter to the facet's right handle.
+        let reqY = baseY + STACKED_REQUIREMENTS_Y_OFFSET
         requirementsFacets.forEach(facet => {
-            updatePosition(facet.id, { x: columnX, y: cursorY })
+            updatePosition(facet.id, { x: columnX, y: reqY })
             const restriction = restrictionForFacet.get(facet.id)
             if (restriction) {
                 updatePosition(restriction.id, {
                     x: columnX + STACKED_RESTRICTION_OFFSET,
-                    y: cursorY,
+                    y: reqY,
                 })
             }
-            cursorY += STACKED_VERTICAL_SPACING
+            reqY += STACKED_VERTICAL_SPACING
         })
     })
 

--- a/lib/node-layout.ts
+++ b/lib/node-layout.ts
@@ -1,5 +1,19 @@
 import type { GraphNode, GraphEdge } from "./graph-types"
 
+/**
+ * Layout mode for arranging the canvas.
+ *
+ * - "grouped"  (default) — facets stacked in a single left-side column, the
+ *   spec node sits to the right of them, and multiple specs are stacked
+ *   vertically. This is the original layout produced by `relayoutNodes`.
+ * - "stacked"  — each specification gets its own vertical column: spec on
+ *   top, applicability facets stacked directly below it, a gap, then the
+ *   requirements facets stacked below that. Multiple specs are placed
+ *   side-by-side horizontally. Toggled via the "Arrange Mode" control in
+ *   the editor header.
+ */
+export type ArrangeMode = "grouped" | "stacked"
+
 export interface LayoutConfig {
     specPosition: { x: number; y: number }
     baseX: number // Left side X position for facet nodes
@@ -19,6 +33,15 @@ export const DEFAULT_LAYOUT_CONFIG: LayoutConfig = {
     horizontalGap: 600,
     nodeHeight: 100,
 }
+
+// Width of one specification column in "stacked" arrange mode. Roughly the
+// spec card width (280px) plus a comfortable horizontal gutter so neighboring
+// columns don't visually collide with restriction nodes that sit to the right.
+const STACKED_COLUMN_WIDTH = 520
+// Vertical pitch between cards within a stacked column.
+const STACKED_VERTICAL_SPACING = 130
+// Horizontal offset of a restriction relative to its parent facet's column.
+const STACKED_RESTRICTION_OFFSET = 280
 
 // Node type priority for ordering within groups
 const NODE_TYPE_PRIORITY: Record<string, number> = {
@@ -299,8 +322,13 @@ export function findTemplateOffset(
 
 export function relayoutNodes(
     nodes: GraphNode[],
-    edges: GraphEdge[]
+    edges: GraphEdge[],
+    mode: ArrangeMode = "grouped"
 ): GraphNode[] {
+    if (mode === "stacked") {
+        return relayoutNodesStacked(nodes, edges)
+    }
+
     const specNodes = nodes.filter(node => node.type === 'spec')
     if (specNodes.length === 0) return nodes
 
@@ -399,6 +427,140 @@ export function relayoutNodes(
                 position: specOffset,
             }
         }
+    })
+
+    return updatedNodes
+}
+
+/**
+ * Vertical-stack layout: every specification becomes its own column.
+ *
+ * Within a column we stack:
+ *   1. the spec node at the top,
+ *   2. its applicability facets directly below (in priority order),
+ *   3. a gap,
+ *   4. its requirements facets below the gap.
+ *
+ * Restrictions are placed in the same column as their parent facet, offset
+ * to the right so the facet → restriction → spec chain stays readable.
+ *
+ * Multiple specifications are laid out side-by-side, left-to-right, in the
+ * order they appear in `nodes` so the user's mental ordering is preserved.
+ *
+ * Any nodes that are not connected to a spec (orphans) are appended in an
+ * extra column on the right so they don't visually overlap arranged content.
+ */
+function relayoutNodesStacked(
+    nodes: GraphNode[],
+    edges: GraphEdge[]
+): GraphNode[] {
+    const specNodes = nodes.filter(node => node.type === 'spec')
+    if (specNodes.length === 0) return nodes
+
+    const updatedNodes = [...nodes]
+    const positioned = new Set<string>()
+
+    const baseX = DEFAULT_LAYOUT_CONFIG.specPosition.x
+    const baseY = DEFAULT_LAYOUT_CONFIG.baseY
+
+    const updatePosition = (id: string, position: { x: number; y: number }) => {
+        const idx = updatedNodes.findIndex(n => n.id === id)
+        if (idx === -1) return
+        updatedNodes[idx] = { ...updatedNodes[idx], position }
+        positioned.add(id)
+    }
+
+    const sortByPriority = (a: GraphNode, b: GraphNode) => {
+        const priorityA = NODE_TYPE_PRIORITY[a.type] || 999
+        const priorityB = NODE_TYPE_PRIORITY[b.type] || 999
+        return priorityA - priorityB
+    }
+
+    specNodes.forEach((specNode, specIndex) => {
+        const columnX = baseX + specIndex * STACKED_COLUMN_WIDTH
+
+        // Place the spec node at the top of its column.
+        updatePosition(specNode.id, { x: columnX, y: baseY })
+
+        // Collect facets connected to this spec, separated by handle. A facet
+        // may be wired either directly to the spec or via a restriction node;
+        // both cases need to be detected so the column ends up complete.
+        const applicabilityFacets: GraphNode[] = []
+        const requirementsFacets: GraphNode[] = []
+        // Map of facet id -> restriction node sitting on the wire to the spec.
+        const restrictionForFacet = new Map<string, GraphNode>()
+
+        nodes.forEach(node => {
+            if (node.type === 'spec' || node.type === 'restriction') return
+
+            // Direct connection: facet -> spec
+            const directEdge = edges.find(e =>
+                e.source === node.id && e.target === specNode.id,
+            )
+            if (directEdge) {
+                if (directEdge.targetHandle === 'applicability') applicabilityFacets.push(node)
+                else if (directEdge.targetHandle === 'requirements') requirementsFacets.push(node)
+                return
+            }
+
+            // Indirect connection: facet -> restriction -> spec
+            const toRestriction = edges.find(e => e.source === node.id)
+            if (!toRestriction) return
+            const maybeRestriction = nodes.find(n => n.id === toRestriction.target)
+            if (!maybeRestriction || maybeRestriction.type !== 'restriction') return
+            const restrictionEdge = edges.find(e =>
+                e.source === maybeRestriction.id && e.target === specNode.id,
+            )
+            if (!restrictionEdge) return
+            if (restrictionEdge.targetHandle === 'applicability') applicabilityFacets.push(node)
+            else if (restrictionEdge.targetHandle === 'requirements') requirementsFacets.push(node)
+            restrictionForFacet.set(node.id, maybeRestriction)
+        })
+
+        applicabilityFacets.sort(sortByPriority)
+        requirementsFacets.sort(sortByPriority)
+
+        // Stack applicability facets directly below the spec.
+        let cursorY = baseY + STACKED_VERTICAL_SPACING
+        applicabilityFacets.forEach(facet => {
+            updatePosition(facet.id, { x: columnX, y: cursorY })
+            const restriction = restrictionForFacet.get(facet.id)
+            if (restriction) {
+                updatePosition(restriction.id, {
+                    x: columnX + STACKED_RESTRICTION_OFFSET,
+                    y: cursorY,
+                })
+            }
+            cursorY += STACKED_VERTICAL_SPACING
+        })
+
+        // Group gap before requirements, so the two sections read as distinct.
+        if (requirementsFacets.length > 0) {
+            cursorY += STACKED_VERTICAL_SPACING * 0.5
+        }
+
+        requirementsFacets.forEach(facet => {
+            updatePosition(facet.id, { x: columnX, y: cursorY })
+            const restriction = restrictionForFacet.get(facet.id)
+            if (restriction) {
+                updatePosition(restriction.id, {
+                    x: columnX + STACKED_RESTRICTION_OFFSET,
+                    y: cursorY,
+                })
+            }
+            cursorY += STACKED_VERTICAL_SPACING
+        })
+    })
+
+    // Park anything that wasn't touched (orphan nodes, dangling restrictions)
+    // in an additional column to the right of the last spec, so the canvas
+    // doesn't end up with overlapping clusters of stale content.
+    const orphanX = baseX + specNodes.length * STACKED_COLUMN_WIDTH
+    let orphanY = baseY
+    updatedNodes.forEach((node, idx) => {
+        if (positioned.has(node.id)) return
+        updatedNodes[idx] = { ...node, position: { x: orphanX, y: orphanY } }
+        orphanY += STACKED_VERTICAL_SPACING
     })
 
     return updatedNodes

--- a/lib/node-layout.ts
+++ b/lib/node-layout.ts
@@ -37,9 +37,13 @@ export const DEFAULT_LAYOUT_CONFIG: LayoutConfig = {
 // Width of one specification column in "stacked" arrange mode. Roughly the
 // spec card width (280px) plus a comfortable horizontal gutter so neighboring
 // columns don't visually collide with restriction nodes that sit to the right.
-const STACKED_COLUMN_WIDTH = 520
-// Vertical pitch between cards within a stacked column.
-const STACKED_VERTICAL_SPACING = 130
+const STACKED_COLUMN_WIDTH = 560
+// Vertical pitch between cards within a stacked column. Generous enough that
+// the orthogonal edges in the right-side gutter don't run into one another
+// and every facet card has clear breathing room.
+const STACKED_VERTICAL_SPACING = 190
+// Vertical gap inserted between the applicability and requirements sections.
+const STACKED_SECTION_GAP = 60
 // Horizontal offset of a restriction relative to its parent facet's column.
 const STACKED_RESTRICTION_OFFSET = 280
 
@@ -536,7 +540,7 @@ function relayoutNodesStacked(
 
         // Group gap before requirements, so the two sections read as distinct.
         if (requirementsFacets.length > 0) {
-            cursorY += STACKED_VERTICAL_SPACING * 0.5
+            cursorY += STACKED_SECTION_GAP
         }
 
         requirementsFacets.forEach(facet => {

--- a/lib/project-session-store.ts
+++ b/lib/project-session-store.ts
@@ -8,6 +8,7 @@
  */
 
 import type { GraphNode, GraphEdge } from "./graph-types"
+import type { ArrangeMode } from "./node-layout"
 
 const STORAGE_KEY = "idsedit-project-state"
 
@@ -15,6 +16,10 @@ interface ProjectState {
   nodes: GraphNode[]
   edges: GraphEdge[]
   ifcVersion: string
+  // Optional so older sessionStorage payloads (from versions before the
+  // arrange-mode toggle existed) still parse cleanly and fall back to the
+  // default "grouped" layout on load.
+  arrangeMode?: ArrangeMode
 }
 
 let cache: ProjectState | null | undefined = undefined
@@ -51,7 +56,17 @@ export function loadProjectState(): ProjectState | null {
       return null
     }
 
-    cache = parsed as ProjectState
+    const arrangeMode: ArrangeMode | undefined =
+      parsed.arrangeMode === "stacked" || parsed.arrangeMode === "grouped"
+        ? parsed.arrangeMode
+        : undefined
+
+    cache = {
+      nodes: parsed.nodes,
+      edges: parsed.edges,
+      ifcVersion: parsed.ifcVersion,
+      arrangeMode,
+    }
     return cache
   } catch {
     cache = null
@@ -65,12 +80,13 @@ export function loadProjectState(): ProjectState | null {
 export function saveProjectState(
   nodes: GraphNode[],
   edges: GraphEdge[],
-  ifcVersion: string
+  ifcVersion: string,
+  arrangeMode?: ArrangeMode,
 ): void {
   try {
     if (typeof window === "undefined") return
 
-    const state: ProjectState = { nodes, edges, ifcVersion }
+    const state: ProjectState = { nodes, edges, ifcVersion, arrangeMode }
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
     // Keep cache in sync
     cache = state


### PR DESCRIPTION
## Summary

Adds an arrange-mode toggle to the canvas so each specification can be viewed as a vertical stack of its facets instead of the existing grouped two-column layout. Picking up the toggle pulled a few related cleanups along for the ride — the edge routing, lane sorting, and a hydration mismatch that the new persisted state exposed — all fixed here.

## What changed

- **New "Stacked" arrange mode** (`components/specification-editor.tsx`, `lib/layout.ts`). Stacked mode places the spec card on top with its facets stacked beneath it, columns side-by-side per spec. Grouped mode (the existing two-column layout) is unchanged and is still the default. The mode is persisted alongside the rest of the project state in sessionStorage.
- **Right-side ports + 90° gutter routing in stacked mode**. Applicability and requirements both leave the spec card from the right edge, applicability facets stack vertically to the right of the spec rather than below it, and edges route as orthogonal paths through a dedicated right-hand gutter so they no longer S-curve across the column.
- **Structured per-edge lanes in grouped mode** (`components/edges/lane-edge.tsx`, `components/graph-canvas.tsx`). New `LaneEdge` custom edge type computes a per-edge trunk X via `getSmoothStepPath`'s `centerX`. Lane indices are derived in the canvas by grouping edges by their target node + target handle and sorting source nodes by Y, so multiple requirements converging on a spec port land in stable, non-crossing vertical lanes that resort cleanly after a drag.
- **Refresh ReactFlow handle bounds on mode flip** (`components/graph-canvas.tsx`). Calls `useUpdateNodeInternals` for every node in a `useEffect` keyed on `arrangeMode`/`nodes`, so edges don't attach to stale cached handle positions after toggling layouts.
- **Defer sessionStorage rehydrate to avoid SSR mismatch** (`components/specification-editor.tsx`). The `useState` initialisers used to call `loadProjectState()` directly, which reads sessionStorage. The editor is a `"use client"` component but Next.js still server-renders it on the first request, so the server saw no storage and rendered the toggle as "Grouped" while the client first-rendered it as "Stacked" — triggering React's hydration mismatch and regenerating the subtree. Now we mount with the same defaults the server uses and rehydrate from sessionStorage in a single post-mount effect, with a `hydrated` flag gating the autosave effect so the empty defaults can't clobber the saved project on the way in.

## Test plan

- [x] `npm run build` / `tsc --noEmit` clean on the touched files
- [x] Toggle Grouped ↔ Stacked from a multi-spec canvas — edges re-route cleanly, no stale handle attachment
- [x] In Stacked mode, applicability facets stack to the right of the spec and edges run as 90° paths in the right gutter
- [x] In Grouped mode, multiple requirements landing on the same spec port occupy distinct vertical lanes and resort after dragging a source node
- [x] Reload with `arrangeMode: "stacked"` in sessionStorage — toggle rehydrates as Stacked, no hydration error in the console
- [ ] Export → re-import a spec built in Stacked mode and confirm IDS XML is unchanged from Grouped



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dual layout modes for graph visualization: **grouped** and **stacked**
  * Improved edge routing: **lane-based routing** in grouped mode and **smooth routing** in stacked mode
  * Enhanced layout controls with a mode toggle and **mode-aware “Arrange All”**
  * Persisted layout preference (**arrangeMode**) across sessions

* **Bug Fixes**
  * Fixed server/client hydration mismatch on initial load

* **Refactor**
  * Improved facet-specific source handle positioning for more consistent connections across modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->