### PR TITLE
Navigate from audit errors to the affected IDS node (#45)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -255,6 +255,37 @@
   }
 }
 
+/* Validation indicators on canvas nodes. Set by graph-canvas as a className on
+   the ReactFlow node wrapper so problem nodes are easy to spot without opening
+   the validation overlay. Red = has an error, amber = warning only. */
+.react-flow__node.rf-node-error [data-slot="card"] {
+  box-shadow: 0 0 0 2px color-mix(in oklch, oklch(0.62 0.22 25) 85%, transparent), 0 0 12px -2px oklch(0.62 0.22 25);
+}
+
+.react-flow__node.rf-node-warning [data-slot="card"] {
+  box-shadow: 0 0 0 2px color-mix(in oklch, oklch(0.78 0.15 75) 85%, transparent), 0 0 12px -2px oklch(0.78 0.15 75);
+}
+
+/* One-shot pulse when the inspector scrolls to a field after clicking an
+   audit error (see FieldIssueWrap in inspector-panel). */
+.field-flash {
+  animation: fieldFlash 1.1s ease-out 1;
+}
+
+@keyframes fieldFlash {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--ring) 55%, transparent);
+  }
+
+  30% {
+    box-shadow: 0 0 0 4px color-mix(in oklch, var(--ring) 35%, transparent);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
 .react-flow__handle {
   width: 10px;
   height: 10px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -267,22 +267,23 @@
 }
 
 /* One-shot pulse when the inspector scrolls to a field after clicking an
-   audit error (see FieldIssueWrap in inspector-panel). */
+   audit error (see FieldIssueWrap in inspector-panel). Uses an *inset* ring so
+   the highlight stays inside the field box and never clips at the panel edge. */
 .field-flash {
-  animation: field-flash 1.1s ease-out 1;
+  animation: field-flash 1.15s ease-out 1;
 }
 
 @keyframes field-flash {
   0% {
-    box-shadow: 0 0 0 0 color-mix(in oklch, var(--ring) 55%, transparent);
+    box-shadow: inset 0 0 0 2px color-mix(in oklch, var(--ring) 60%, transparent);
   }
 
-  30% {
-    box-shadow: 0 0 0 4px color-mix(in oklch, var(--ring) 35%, transparent);
+  55% {
+    box-shadow: inset 0 0 0 2px color-mix(in oklch, var(--ring) 28%, transparent);
   }
 
   100% {
-    box-shadow: 0 0 0 0 transparent;
+    box-shadow: inset 0 0 0 2px transparent;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -269,10 +269,10 @@
 /* One-shot pulse when the inspector scrolls to a field after clicking an
    audit error (see FieldIssueWrap in inspector-panel). */
 .field-flash {
-  animation: fieldFlash 1.1s ease-out 1;
+  animation: field-flash 1.1s ease-out 1;
 }
 
-@keyframes fieldFlash {
+@keyframes field-flash {
   0% {
     box-shadow: 0 0 0 0 color-mix(in oklch, var(--ring) 55%, transparent);
   }

--- a/components/canvas-validation-overlay.tsx
+++ b/components/canvas-validation-overlay.tsx
@@ -55,8 +55,14 @@ function deriveStatus(
     field: i.field,
   }))
 
-  // Surface server / parser failures as errors
-  if (validationState.status === "error") {
+  // Surface server / parser failures as errors — but only when they aren't
+  // already itemized as client issues. On client-side failure, validationState
+  // .error is just those same issues joined into a string, so unshifting it
+  // would duplicate every row (one aggregate copy + one per-issue copy). Only
+  // show it for non-itemized failures (an exception or parse error with no
+  // per-node issues to click).
+  const hasClientErrors = clientIssues.some((i) => i.severity === "error")
+  if (validationState.status === "error" && !hasClientErrors) {
     issues.unshift({
       severity: "error",
       message: validationState.error || "Validation failed",
@@ -223,57 +229,55 @@ export function CanvasValidationOverlay({
         </button>
 
         {expanded && issues.length > 0 ? (
-          <div className="border-t border-border/60 max-h-[280px] overflow-y-auto">
-            <ul className="py-1">
+          // Neutral surface for the list so red icons/accents read clearly
+          // instead of fighting the red-tinted header (red-on-red).
+          <div className="rounded-b-lg border-t border-border/60 bg-popover/95">
+            <ul className="max-h-[280px] space-y-0.5 overflow-y-auto p-1.5">
               {issues.map((issue, idx) => {
                 const linkable = Boolean(issue.nodeId && onIssueSelect)
-                const Icon =
-                  issue.severity === "error" ? (
-                    <XCircle className="mt-0.5 h-3 w-3 flex-shrink-0 text-red-500" />
-                  ) : (
-                    <AlertCircle className="mt-0.5 h-3 w-3 flex-shrink-0 text-amber-500" />
-                  )
+                const isError = issue.severity === "error"
                 const body = (
                   <>
-                    {Icon}
+                    {/* Severity rail — a calm accent rather than a flood of red */}
+                    <span
+                      aria-hidden
+                      className={cn(
+                        "mt-0.5 w-0.5 self-stretch rounded-full",
+                        isError ? "bg-red-500/70" : "bg-amber-500/70"
+                      )}
+                    />
+                    {isError ? (
+                      <XCircle className="mt-px h-3.5 w-3.5 flex-shrink-0 text-red-500" />
+                    ) : (
+                      <AlertCircle className="mt-px h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
+                    )}
                     <div className="min-w-0 flex-1">
-                      <div
-                        className={cn(
-                          issue.severity === "error"
-                            ? "text-red-600 dark:text-red-400"
-                            : "text-amber-600 dark:text-amber-400"
-                        )}
-                      >
-                        {issue.message}
-                      </div>
+                      <div className="text-foreground/90">{issue.message}</div>
                       {issue.detail ? (
-                        <div className="mt-0.5 text-muted-foreground font-mono text-[10px] break-words">
+                        <div className="mt-0.5 break-words font-mono text-[10px] text-muted-foreground">
                           {issue.detail}
                         </div>
                       ) : null}
                     </div>
                     {linkable ? (
-                      <Locate className="mt-0.5 h-3 w-3 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+                      <Locate className="mt-px h-3.5 w-3.5 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
                     ) : null}
                   </>
                 )
                 return (
-                  <li
-                    key={idx}
-                    className="border-b border-border/30 last:border-b-0"
-                  >
+                  <li key={idx}>
                     {linkable ? (
                       <button
                         type="button"
                         onClick={() => onIssueSelect!(issue.nodeId!, issue.field)}
                         title="Go to node"
                         aria-label={`Go to node: ${issue.message}`}
-                        className="group flex w-full items-start gap-2 px-2.5 py-1.5 text-left text-[11px] leading-snug hover:bg-foreground/5 cursor-pointer"
+                        className="group flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-[11px] leading-snug transition-colors hover:bg-foreground/[0.06]"
                       >
                         {body}
                       </button>
                     ) : (
-                      <div className="flex items-start gap-2 px-2.5 py-1.5 text-[11px] leading-snug">
+                      <div className="flex items-start gap-2 rounded-md px-2 py-1.5 text-[11px] leading-snug">
                         {body}
                       </div>
                     )}

--- a/components/canvas-validation-overlay.tsx
+++ b/components/canvas-validation-overlay.tsx
@@ -11,6 +11,7 @@ import {
   ChevronUp,
   RefreshCw,
   Sparkles,
+  Locate,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -22,6 +23,8 @@ interface CanvasValidationOverlayProps {
   isValidating: boolean
   isDisabled: boolean
   onValidateNow?: () => void
+  /** Jump to + select the node a validation issue points at. */
+  onIssueSelect?: (nodeId: string, field?: string) => void
 }
 
 type OverlayStatus = "idle" | "loading" | "valid" | "warning" | "error"
@@ -30,6 +33,10 @@ interface DisplayIssue {
   severity: "error" | "warning"
   message: string
   detail?: string
+  // Carried through from the client-side ValidationIssue so each row can link
+  // back to its node. Absent for parser/structure errors that aren't mapped.
+  nodeId?: string
+  field?: string
 }
 
 function deriveStatus(
@@ -44,6 +51,8 @@ function deriveStatus(
   const issues: DisplayIssue[] = clientIssues.map((i) => ({
     severity: i.severity,
     message: i.message,
+    nodeId: i.nodeId,
+    field: i.field,
   }))
 
   // Surface server / parser failures as errors
@@ -126,6 +135,7 @@ export function CanvasValidationOverlay({
   isValidating,
   isDisabled,
   onValidateNow,
+  onIssueSelect,
 }: CanvasValidationOverlayProps) {
   const [expanded, setExpanded] = useState(false)
 
@@ -215,37 +225,61 @@ export function CanvasValidationOverlay({
         {expanded && issues.length > 0 ? (
           <div className="border-t border-border/60 max-h-[280px] overflow-y-auto">
             <ul className="py-1">
-              {issues.map((issue, idx) => (
-                <li
-                  key={idx}
-                  className={cn(
-                    "flex items-start gap-2 px-2.5 py-1.5 text-[11px] leading-snug",
-                    "border-b border-border/30 last:border-b-0"
-                  )}
-                >
-                  {issue.severity === "error" ? (
+              {issues.map((issue, idx) => {
+                const linkable = Boolean(issue.nodeId && onIssueSelect)
+                const Icon =
+                  issue.severity === "error" ? (
                     <XCircle className="mt-0.5 h-3 w-3 flex-shrink-0 text-red-500" />
                   ) : (
                     <AlertCircle className="mt-0.5 h-3 w-3 flex-shrink-0 text-amber-500" />
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <div
-                      className={cn(
-                        issue.severity === "error"
-                          ? "text-red-600 dark:text-red-400"
-                          : "text-amber-600 dark:text-amber-400"
-                      )}
-                    >
-                      {issue.message}
-                    </div>
-                    {issue.detail ? (
-                      <div className="mt-0.5 text-muted-foreground font-mono text-[10px] break-words">
-                        {issue.detail}
+                  )
+                const body = (
+                  <>
+                    {Icon}
+                    <div className="min-w-0 flex-1">
+                      <div
+                        className={cn(
+                          issue.severity === "error"
+                            ? "text-red-600 dark:text-red-400"
+                            : "text-amber-600 dark:text-amber-400"
+                        )}
+                      >
+                        {issue.message}
                       </div>
+                      {issue.detail ? (
+                        <div className="mt-0.5 text-muted-foreground font-mono text-[10px] break-words">
+                          {issue.detail}
+                        </div>
+                      ) : null}
+                    </div>
+                    {linkable ? (
+                      <Locate className="mt-0.5 h-3 w-3 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
                     ) : null}
-                  </div>
-                </li>
-              ))}
+                  </>
+                )
+                return (
+                  <li
+                    key={idx}
+                    className="border-b border-border/30 last:border-b-0"
+                  >
+                    {linkable ? (
+                      <button
+                        type="button"
+                        onClick={() => onIssueSelect!(issue.nodeId!, issue.field)}
+                        title="Go to node"
+                        aria-label={`Go to node: ${issue.message}`}
+                        className="group flex w-full items-start gap-2 px-2.5 py-1.5 text-left text-[11px] leading-snug hover:bg-foreground/5 cursor-pointer"
+                      >
+                        {body}
+                      </button>
+                    ) : (
+                      <div className="flex items-start gap-2 px-2.5 py-1.5 text-[11px] leading-snug">
+                        {body}
+                      </div>
+                    )}
+                  </li>
+                )
+              })}
             </ul>
             {onValidateNow ? (
               <div className="border-t border-border/40 p-1.5">

--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -40,6 +40,14 @@ interface GraphCanvasProps {
    */
   pendingSelectionIds?: string[] | null
   onPendingSelectionConsumed?: () => void
+  /**
+   * Node the canvas should center+zoom onto (set when the user clicks a
+   * validation error). Cleared via onPendingFocusConsumed once applied.
+   */
+  pendingFocusNodeId?: string | null
+  onPendingFocusConsumed?: () => void
+  /** Jump to + select the node a validation error points at. */
+  onIssueSelect?: (nodeId: string, field?: string) => void
   validationState?: ValidationState
   isValidating?: boolean
   isValidationDisabled?: boolean
@@ -58,7 +66,7 @@ const nodeTypes = {
 }
 
 
-export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes, onAddNode, pendingSelectionIds, onPendingSelectionConsumed, validationState, isValidating = false, isValidationDisabled = false, onValidateNow }: GraphCanvasProps) {
+export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes, onAddNode, pendingSelectionIds, onPendingSelectionConsumed, pendingFocusNodeId, onPendingFocusConsumed, onIssueSelect, validationState, isValidating = false, isValidationDisabled = false, onValidateNow }: GraphCanvasProps) {
   const [showMinimap, setShowMinimap] = useState(true)
   const [focusedSpecTargets, setFocusedSpecTargets] = useState<Record<string, 'applicability' | 'requirements'>>({})
   const [focusedFacetColor, setFocusedFacetColor] = useState<string | null>(null)
@@ -213,6 +221,53 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
       }))
     })
   }, [initialEdges, setEdges])
+
+  // Mark nodes that have validation issues so they stand out on the canvas
+  // (red ring for errors, amber for warning-only). Done as a className on the
+  // ReactFlow node wrapper via CSS — avoids threading an error flag through all
+  // eight node components. Runs on validation changes only; the baseNodes sync
+  // effect preserves className across position/data updates.
+  useEffect(() => {
+    const issues = validationState?.clientIssues ?? []
+    const errorIds = new Set<string>()
+    const warnIds = new Set<string>()
+    for (const issue of issues) {
+      if (!issue.nodeId) continue
+      if (issue.severity === 'error') errorIds.add(issue.nodeId)
+      else warnIds.add(issue.nodeId)
+    }
+    setNodes((currentNodes) =>
+      currentNodes.map((node) => {
+        const cls = errorIds.has(node.id)
+          ? 'rf-node-error'
+          : warnIds.has(node.id)
+            ? 'rf-node-warning'
+            : undefined
+        if ((node.className ?? undefined) === cls) return node
+        return { ...node, className: cls }
+      })
+    )
+  }, [validationState?.clientIssues, setNodes])
+
+  // Center+zoom the canvas onto the node a validation error points at.
+  useEffect(() => {
+    if (!pendingFocusNodeId) return
+    const present = reactFlowNodes.some((n) => n.id === pendingFocusNodeId)
+    if (!present) {
+      // Stale id (e.g. node deleted before re-validation). Consume the request
+      // so it doesn't stick and a later click on the same id can re-fire.
+      onPendingFocusConsumed?.()
+      return
+    }
+    reactFlowInstance.fitView({
+      nodes: [{ id: pendingFocusNodeId }],
+      duration: 500,
+      maxZoom: 1.3,
+      minZoom: 0.5,
+      padding: 0.5,
+    })
+    onPendingFocusConsumed?.()
+  }, [pendingFocusNodeId, reactFlowNodes, reactFlowInstance, onPendingFocusConsumed])
 
   const onConnectHandler: OnConnect = useCallback((connection: Connection) => {
     if (connection.source && connection.target) {
@@ -501,8 +556,11 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
             zoomable
             inversePan
             nodeColor={(node) => {
-              const baseColor = FACET_COLORS[node.type as keyof typeof FACET_COLORS]?.minimap || 'oklch(0.55 0.18 265)'
-              return node.selected ? 'oklch(0.90 0.15 292)' : baseColor
+              if (node.selected) return 'oklch(0.90 0.15 292)'
+              // Surface validation errors on the minimap too, so off-screen
+              // problem nodes are visible at a glance.
+              if (node.className?.includes('rf-node-error')) return 'oklch(0.62 0.22 25)'
+              return FACET_COLORS[node.type as keyof typeof FACET_COLORS]?.minimap || 'oklch(0.55 0.18 265)'
             }}
             nodeClassName={(node) => node.selected ? 'minimap-selected-node' : ''}
           />
@@ -515,6 +573,7 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
             isValidating={isValidating}
             isDisabled={isValidationDisabled}
             onValidateNow={onValidateNow}
+            onIssueSelect={onIssueSelect}
           />
         )}
       </ReactFlow>

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useRef, useContext, createContext } from "react"
 import { Card } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -42,7 +42,77 @@ import {
   type CustomPropertySet
 } from "@/lib/custom-schema-store"
 import type { ValidationState } from "@/lib/use-ids-validation"
-import { CheckCircle2, XCircle, AlertCircle, Loader2, RefreshCw, MousePointerClick, Info, Zap, PlusCircle, Link2, Eye, ExternalLink, BookOpen, Filter } from "lucide-react"
+import type { ValidationIssue } from "@/lib/ids-client-validation"
+import { cn } from "@/lib/utils"
+import { CheckCircle2, XCircle, AlertCircle, Loader2, RefreshCw, MousePointerClick, Info, Zap, PlusCircle, Link2, Eye, ExternalLink, BookOpen, Filter, Locate } from "lucide-react"
+
+// Active field-highlight request from a clicked validation error. `field` is the
+// data field to flash/scroll to; `nonce` lets a repeat click re-trigger it.
+type ActiveIssueField = { nodeId: string; field?: string; nonce: number } | null
+
+interface FieldIssueInfo {
+  severity: "error" | "warning"
+  message: string
+}
+
+// Context so individual field blocks can pick up their own validation issue
+// (red ring + inline message) and the scroll-to/flash request without every
+// *Fields component threading the props through. Scoped to the selected node.
+const FieldIssueContext = createContext<{
+  errors: Record<string, FieldIssueInfo>
+  active: { field?: string; nonce: number } | null
+}>({ errors: {}, active: null })
+
+// Wrap a field block to ring it when the selected node has an issue on that
+// field, show the message inline, and scroll+flash it when an error is clicked.
+function FieldIssueWrap({ field, children }: { field: string; children: React.ReactNode }) {
+  const { errors, active } = useContext(FieldIssueContext)
+  const info = errors[field]
+  const ref = useRef<HTMLDivElement>(null)
+  const isActive = active?.field === field
+  const nonce = active?.nonce
+
+  useEffect(() => {
+    if (!isActive || !ref.current) return
+    const el = ref.current
+    el.scrollIntoView({ behavior: "smooth", block: "center" })
+    el.classList.remove("field-flash")
+    // Force reflow so re-adding the class restarts the animation on repeat clicks.
+    void el.offsetWidth
+    el.classList.add("field-flash")
+  }, [isActive, nonce])
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-md transition-shadow",
+        info && "p-2 -mx-2 ring-1",
+        info?.severity === "error" && "ring-red-500/50 bg-red-500/5",
+        info?.severity === "warning" && "ring-amber-500/50 bg-amber-500/5",
+      )}
+    >
+      {children}
+      {info && (
+        <p
+          className={cn(
+            "mt-1.5 flex items-start gap-1 text-[11px] leading-snug",
+            info.severity === "error"
+              ? "text-red-600 dark:text-red-400"
+              : "text-amber-600 dark:text-amber-400",
+          )}
+        >
+          {info.severity === "error" ? (
+            <XCircle className="mt-0.5 h-3 w-3 flex-shrink-0" />
+          ) : (
+            <AlertCircle className="mt-0.5 h-3 w-3 flex-shrink-0" />
+          )}
+          <span>{info.message}</span>
+        </p>
+      )}
+    </div>
+  )
+}
 
 interface InspectorPanelProps {
   selectedNode: Node<any> | null
@@ -55,6 +125,10 @@ interface InspectorPanelProps {
   nodes: GraphNode[]
   edges: GraphEdge[]
   onConvertValueToRestriction?: (facetNodeId: string, fieldName: string, values: string[]) => void
+  /** Jump to + select the node a validation issue points at. */
+  onIssueSelect?: (nodeId: string, field?: string) => void
+  /** Field the user asked to jump to (drives the inspector scroll/flash). */
+  activeIssueField?: ActiveIssueField
 }
 
 // Module-level cache for inspector schema lookups. Each field component's
@@ -193,7 +267,9 @@ export function InspectorPanel({
   ifcVersion = "IFC4X3_ADD2",
   nodes,
   edges,
-  onConvertValueToRestriction
+  onConvertValueToRestriction,
+  onIssueSelect,
+  activeIssueField
 }: InspectorPanelProps) {
   if (!selectedNode) {
     return (
@@ -370,6 +446,21 @@ export function InspectorPanel({
     onUpdateNode(selectedNode.id, { [field]: value })
   }
 
+  // Validation issues that belong to the selected node, indexed by field, so
+  // each field block can ring itself and the jump-to-field flash can target it.
+  const clientIssues = validationState?.clientIssues ?? []
+  const selectedNodeIssues = clientIssues.filter((i) => i.nodeId === selectedNode.id)
+  const fieldErrors: Record<string, FieldIssueInfo> = {}
+  for (const issue of selectedNodeIssues) {
+    if (issue.field && !fieldErrors[issue.field]) {
+      fieldErrors[issue.field] = { severity: issue.severity, message: issue.message }
+    }
+  }
+  const fieldActive =
+    activeIssueField && activeIssueField.nodeId === selectedNode.id
+      ? { field: activeIssueField.field, nonce: activeIssueField.nonce }
+      : null
+
   return (
     <Card className="h-full rounded-none border-l border-border bg-sidebar flex flex-col overflow-hidden">
       <ScrollArea className="flex-1 min-h-0">
@@ -387,18 +478,24 @@ export function InspectorPanel({
             )}
           </div>
           {/* Validation Issues (if any) */}
-          {validationState && validationState.clientIssues && validationState.clientIssues.length > 0 && (
-            <ValidationIssues issues={validationState.clientIssues} />
+          {clientIssues.length > 0 && (
+            <ValidationIssues
+              issues={clientIssues}
+              selectedNodeId={selectedNode.id}
+              onIssueSelect={onIssueSelect}
+            />
           )}
           {/* Node Properties */}
-          {selectedNode.type === "spec" && <SpecificationFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} />}
-          {selectedNode.type === "entity" && <EntityFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
-          {selectedNode.type === "property" && <PropertyFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
-          {selectedNode.type === "attribute" && <AttributeFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
-          {selectedNode.type === "classification" && <ClassificationFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
-          {selectedNode.type === "material" && <MaterialFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
-          {selectedNode.type === "partOf" && <PartOfFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
-          {selectedNode.type === "restriction" && <RestrictionFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} />}
+          <FieldIssueContext.Provider value={{ errors: fieldErrors, active: fieldActive }}>
+            {selectedNode.type === "spec" && <SpecificationFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} />}
+            {selectedNode.type === "entity" && <EntityFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
+            {selectedNode.type === "property" && <PropertyFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
+            {selectedNode.type === "attribute" && <AttributeFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
+            {selectedNode.type === "classification" && <ClassificationFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
+            {selectedNode.type === "material" && <MaterialFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} onConvertValueToRestriction={onConvertValueToRestriction} />}
+            {selectedNode.type === "partOf" && <PartOfFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} nodes={nodes} edges={edges} />}
+            {selectedNode.type === "restriction" && <RestrictionFields node={selectedNode} onChange={handleChange} ifcVersion={ifcVersion} />}
+          </FieldIssueContext.Provider>
         </div>
       </ScrollArea>
     </Card>
@@ -613,6 +710,7 @@ function EntityFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node
 
   return (
     <>
+      <FieldIssueWrap field="name">
       <div className="space-y-2">
         <Label htmlFor="name" className="text-sidebar-foreground">
           Entity Name
@@ -636,6 +734,7 @@ function EntityFields({ node, onChange, ifcVersion, nodes, edges }: { node: Node
           disabled={loading}
         />
       </div>
+      </FieldIssueWrap>
       {predefinedTypes.length > 0 && (
         <div className="space-y-2">
           <Label htmlFor="predefinedType" className="text-sidebar-foreground">
@@ -912,6 +1011,7 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           }}
         />
       </div>
+      <FieldIssueWrap field="dataType">
       <div className="space-y-2">
         <Label htmlFor="dataType" className="text-sidebar-foreground">
           Data Type
@@ -942,6 +1042,7 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           maxHeight={300}
         />
       </div>
+      </FieldIssueWrap>
       <div className="space-y-2">
         <Label htmlFor="value" className="text-sidebar-foreground">
           Value (Optional)
@@ -1696,27 +1797,79 @@ function ValidationBadge({
   )
 }
 
-function ValidationIssues({ issues }: { issues: Array<{ severity: 'error' | 'warning'; message: string }> }) {
-  return (
-    <div className="mt-3 space-y-1">
-      {issues.map((issue, index) => (
-        <div
-          key={index}
-          className={`text-xs p-2 rounded ${issue.severity === 'error'
-            ? 'bg-red-500/10 text-red-500 border border-red-500/20'
-            : 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-500 border border-yellow-500/20'
-            }`}
+function ValidationIssues({
+  issues,
+  selectedNodeId,
+  onIssueSelect,
+}: {
+  issues: ValidationIssue[]
+  selectedNodeId?: string
+  onIssueSelect?: (nodeId: string, field?: string) => void
+}) {
+  // Split the global issue list so the selected node's own problems surface
+  // first; everything else is one click away via onIssueSelect.
+  const onThisNode = issues.filter((i) => i.nodeId && i.nodeId === selectedNodeId)
+  const elsewhere = issues.filter((i) => !i.nodeId || i.nodeId !== selectedNodeId)
+
+  const renderRow = (issue: ValidationIssue, key: string, linkable: boolean) => {
+    const colorClass =
+      issue.severity === 'error'
+        ? 'bg-red-500/10 text-red-500 border border-red-500/20'
+        : 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-500 border border-yellow-500/20'
+    const content = (
+      <div className="flex items-start gap-1.5">
+        {issue.severity === 'error' ? (
+          <XCircle className="h-3 w-3 mt-0.5 flex-shrink-0" />
+        ) : (
+          <AlertCircle className="h-3 w-3 mt-0.5 flex-shrink-0" />
+        )}
+        <span className="leading-tight flex-1">{issue.message}</span>
+        {linkable && (
+          <Locate className="h-3 w-3 mt-0.5 flex-shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+        )}
+      </div>
+    )
+    if (linkable && onIssueSelect) {
+      return (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onIssueSelect(issue.nodeId!, issue.field)}
+          title="Go to node"
+          aria-label={`Go to node: ${issue.message}`}
+          className={`group block w-full text-left text-xs p-2 rounded transition-[filter] hover:brightness-125 ${colorClass}`}
         >
-          <div className="flex items-start gap-1.5">
-            {issue.severity === 'error' ? (
-              <XCircle className="h-3 w-3 mt-0.5 flex-shrink-0" />
-            ) : (
-              <AlertCircle className="h-3 w-3 mt-0.5 flex-shrink-0" />
-            )}
-            <span className="leading-tight flex-1">{issue.message}</span>
-          </div>
+          {content}
+        </button>
+      )
+    }
+    return (
+      <div key={key} className={`text-xs p-2 rounded ${colorClass}`}>
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      {onThisNode.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            On this node
+          </p>
+          {onThisNode.map((issue, i) => renderRow(issue, `this-${i}`, false))}
         </div>
-      ))}
+      )}
+      {elsewhere.length > 0 && (
+        <div className="space-y-1">
+          {onThisNode.length > 0 && (
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Elsewhere ({elsewhere.length})
+            </p>
+          )}
+          {elsewhere.map((issue, i) => renderRow(issue, `else-${i}`, Boolean(issue.nodeId)))}
+        </div>
+      )}
     </div>
   )
 }

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -63,8 +63,16 @@ const FieldIssueContext = createContext<{
   active: { field?: string; nonce: number } | null
 }>({ errors: {}, active: null })
 
-// Wrap a field block to ring it when the selected node has an issue on that
-// field, show the message inline, and scroll+flash it when an error is clicked.
+/**
+ * Wraps a single inspector field so it reacts to the selected node's validation
+ * issues: rings the control (red for errors, amber for warnings), shows the
+ * issue message inline, and — when the user clicks the matching audit error —
+ * scrolls the field into view and plays a one-shot flash. Reads everything from
+ * {@link FieldIssueContext}, so callers only pass the field key.
+ *
+ * @param field - The data field this block edits (e.g. `"dataType"`), matched
+ *   against the active node's issues and the jump-to-field request.
+ */
 function FieldIssueWrap({ field, children }: { field: string; children: React.ReactNode }) {
   const { errors, active } = useContext(FieldIssueContext)
   const info = errors[field]
@@ -1797,6 +1805,15 @@ function ValidationBadge({
   )
 }
 
+/**
+ * Renders the inspector's validation issue list, partitioned into the selected
+ * node's own problems ("On this node") and everything else ("Elsewhere"). Rows
+ * for other nodes are clickable and call {@link onIssueSelect} to jump to them.
+ *
+ * @param issues - All client-side validation issues for the current graph.
+ * @param selectedNodeId - The currently selected node, used to partition rows.
+ * @param onIssueSelect - Invoked with a row's `(nodeId, field)` to navigate to it.
+ */
 function ValidationIssues({
   issues,
   selectedNodeId,

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -94,26 +94,30 @@ function FieldIssueWrap({ field, children }: { field: string; children: React.Re
     <div
       ref={ref}
       className={cn(
-        "rounded-md transition-shadow",
-        info && "p-2 -mx-2 ring-1",
-        info?.severity === "error" && "ring-red-500/50 bg-red-500/5",
-        info?.severity === "warning" && "ring-amber-500/50 bg-amber-500/5",
+        "rounded-lg transition-all",
+        // ring-inset keeps the highlight inside the box so it never bleeds past
+        // the panel edge and gets clipped. No negative margin for the same
+        // reason. Padding only appears in the error state (a deliberate focus
+        // cue), so unaffected fields stay flush with the rest of the form.
+        info && "p-2.5 ring-1 ring-inset",
+        info?.severity === "error" && "bg-red-500/[0.06] ring-red-500/30",
+        info?.severity === "warning" && "bg-amber-500/[0.06] ring-amber-500/30",
       )}
     >
       {children}
       {info && (
         <p
           className={cn(
-            "mt-1.5 flex items-start gap-1 text-[11px] leading-snug",
+            "mt-2 flex items-start gap-1.5 text-[11px] font-medium leading-snug",
             info.severity === "error"
               ? "text-red-600 dark:text-red-400"
               : "text-amber-600 dark:text-amber-400",
           )}
         >
           {info.severity === "error" ? (
-            <XCircle className="mt-0.5 h-3 w-3 flex-shrink-0" />
+            <XCircle className="mt-px h-3.5 w-3.5 flex-shrink-0" />
           ) : (
-            <AlertCircle className="mt-0.5 h-3 w-3 flex-shrink-0" />
+            <AlertCircle className="mt-px h-3.5 w-3.5 flex-shrink-0" />
           )}
           <span>{info.message}</span>
         </p>
@@ -912,6 +916,7 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
 
   return (
     <>
+      <FieldIssueWrap field="propertySet">
       <div className="space-y-2">
         <Label htmlFor="propertySet" className="text-sidebar-foreground">
           Property Set
@@ -972,6 +977,8 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           }}
         />
       </div>
+      </FieldIssueWrap>
+      <FieldIssueWrap field="baseName">
       <div className="space-y-2">
         <Label htmlFor="baseName" className="text-sidebar-foreground">
           Base Name
@@ -1019,6 +1026,7 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           }}
         />
       </div>
+      </FieldIssueWrap>
       <FieldIssueWrap field="dataType">
       <div className="space-y-2">
         <Label htmlFor="dataType" className="text-sidebar-foreground">
@@ -1823,26 +1831,38 @@ function ValidationIssues({
   selectedNodeId?: string
   onIssueSelect?: (nodeId: string, field?: string) => void
 }) {
-  // Split the global issue list so the selected node's own problems surface
-  // first; everything else is one click away via onIssueSelect.
-  const onThisNode = issues.filter((i) => i.nodeId && i.nodeId === selectedNodeId)
+  // The selected node's *field* issues are already shown inline at their
+  // controls (see FieldIssueWrap), so listing them here too would repeat the
+  // same message two or three times. Surface only this node's node-level issues
+  // (no specific field) plus a clickable group for problems on other nodes.
+  const onThisNode = issues.filter(
+    (i) => i.nodeId === selectedNodeId && !i.field,
+  )
   const elsewhere = issues.filter((i) => !i.nodeId || i.nodeId !== selectedNodeId)
 
   const renderRow = (issue: ValidationIssue, key: string, linkable: boolean) => {
-    const colorClass =
-      issue.severity === 'error'
-        ? 'bg-red-500/10 text-red-500 border border-red-500/20'
-        : 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-500 border border-yellow-500/20'
+    const isError = issue.severity === 'error'
+    const tone = isError
+      ? 'bg-red-500/[0.06] ring-red-500/25'
+      : 'bg-amber-500/[0.06] ring-amber-500/25'
     const content = (
-      <div className="flex items-start gap-1.5">
-        {issue.severity === 'error' ? (
-          <XCircle className="h-3 w-3 mt-0.5 flex-shrink-0" />
+      <div className="flex items-start gap-2">
+        {/* Severity rail — accent, not a flood of colour */}
+        <span
+          aria-hidden
+          className={cn(
+            'mt-0.5 w-0.5 self-stretch rounded-full',
+            isError ? 'bg-red-500/70' : 'bg-amber-500/70',
+          )}
+        />
+        {isError ? (
+          <XCircle className="mt-px h-3.5 w-3.5 flex-shrink-0 text-red-500" />
         ) : (
-          <AlertCircle className="h-3 w-3 mt-0.5 flex-shrink-0" />
+          <AlertCircle className="mt-px h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
         )}
-        <span className="leading-tight flex-1">{issue.message}</span>
+        <span className="flex-1 leading-snug text-foreground/90">{issue.message}</span>
         {linkable && (
-          <Locate className="h-3 w-3 mt-0.5 flex-shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+          <Locate className="mt-px h-3.5 w-3.5 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
         )}
       </div>
     )
@@ -1854,36 +1874,39 @@ function ValidationIssues({
           onClick={() => onIssueSelect(issue.nodeId!, issue.field)}
           title="Go to node"
           aria-label={`Go to node: ${issue.message}`}
-          className={`group block w-full text-left text-xs p-2 rounded transition-[filter] hover:brightness-125 ${colorClass}`}
+          className={cn(
+            'group block w-full rounded-lg px-2.5 py-2 text-left text-xs ring-1 ring-inset transition-colors hover:bg-foreground/[0.04]',
+            tone,
+          )}
         >
           {content}
         </button>
       )
     }
     return (
-      <div key={key} className={`text-xs p-2 rounded ${colorClass}`}>
+      <div key={key} className={cn('rounded-lg px-2.5 py-2 text-xs ring-1 ring-inset', tone)}>
         {content}
       </div>
     )
   }
 
+  if (onThisNode.length === 0 && elsewhere.length === 0) return null
+
   return (
-    <div className="mt-3 space-y-2">
+    <div className="space-y-2.5">
       {onThisNode.length > 0 && (
-        <div className="space-y-1">
-          <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
             On this node
           </p>
           {onThisNode.map((issue, i) => renderRow(issue, `this-${i}`, false))}
         </div>
       )}
       {elsewhere.length > 0 && (
-        <div className="space-y-1">
-          {onThisNode.length > 0 && (
-            <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Elsewhere ({elsewhere.length})
-            </p>
-          )}
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+            {elsewhere.length} issue{elsewhere.length === 1 ? '' : 's'} elsewhere
+          </p>
           {elsewhere.map((issue, i) => renderRow(issue, `else-${i}`, Boolean(issue.nodeId)))}
         </div>
       )}

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -50,6 +50,17 @@ export function SpecificationEditor() {
   // conversion, IDS/JSON import) become the current selection without a
   // manual click.
   const [pendingSelectionIds, setPendingSelectionIds] = useState<string[] | null>(null)
+  // Pending viewport-focus request. When set, GraphCanvas animates the canvas
+  // to center+zoom the node, then clears it via onPendingFocusConsumed. Used by
+  // the "click a validation error → jump to its node" flow. Separate from
+  // pendingSelectionIds because focus must run inside the ReactFlowProvider
+  // (it needs useReactFlow), while selection is plain node state.
+  const [pendingFocusNodeId, setPendingFocusNodeId] = useState<string | null>(null)
+  // The field a validation error points at (e.g. 'dataType'), with a nonce so
+  // clicking the same error twice re-triggers the inspector's flash/scroll.
+  const [activeIssueField, setActiveIssueField] = useState<
+    { nodeId: string; field?: string; nonce: number } | null
+  >(null)
   const [ifcVersion, setIfcVersion] = useState<IFCVersion>(() => {
     const saved = loadProjectState()
     return (saved?.ifcVersion as IFCVersion) || "IFC4X3_ADD2"
@@ -652,6 +663,16 @@ export function SpecificationEditor() {
     setPendingSelectionIds([restrictionId])
   }, [nodes, takeSnapshot])
 
+  // Navigate to the node a validation error points at: select it (so the
+  // inspector opens on it), center+zoom the canvas onto it, and remember the
+  // offending field so the inspector can highlight/scroll to it. Wired to both
+  // the canvas overlay and the inspector's issue list.
+  const handleIssueSelect = useCallback((nodeId: string, field?: string) => {
+    setPendingSelectionIds([nodeId])
+    setPendingFocusNodeId(nodeId)
+    setActiveIssueField((prev) => ({ nodeId, field, nonce: (prev?.nonce ?? 0) + 1 }))
+  }, [])
+
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">
       {/* Header row */}
@@ -891,6 +912,9 @@ export function SpecificationEditor() {
                 onAddNode={addNode}
                 pendingSelectionIds={pendingSelectionIds}
                 onPendingSelectionConsumed={() => setPendingSelectionIds(null)}
+                pendingFocusNodeId={pendingFocusNodeId}
+                onPendingFocusConsumed={() => setPendingFocusNodeId(null)}
+                onIssueSelect={handleIssueSelect}
                 validationState={validationState}
                 isValidating={isValidating}
                 isValidationDisabled={isValidationDisabled}
@@ -910,6 +934,8 @@ export function SpecificationEditor() {
                 nodes={nodes}
                 edges={edges}
                 onConvertValueToRestriction={convertValueToRestriction}
+                onIssueSelect={handleIssueSelect}
+                activeIssueField={activeIssueField}
               />
             </Panel>
           </PanelGroup>

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -663,10 +663,13 @@ export function SpecificationEditor() {
     setPendingSelectionIds([restrictionId])
   }, [nodes, takeSnapshot])
 
-  // Navigate to the node a validation error points at: select it (so the
-  // inspector opens on it), center+zoom the canvas onto it, and remember the
-  // offending field so the inspector can highlight/scroll to it. Wired to both
-  // the canvas overlay and the inspector's issue list.
+  /**
+   * Navigate to the node a validation error points at: select it (so the
+   * inspector opens on it), center+zoom the canvas onto it, and remember the
+   * offending field so the inspector can highlight/scroll to it. Wired to both
+   * the canvas overlay and the inspector's issue list. The nonce makes clicking
+   * the same error twice re-trigger the inspector's scroll/flash.
+   */
   const handleIssueSelect = useCallback((nodeId: string, field?: string) => {
     setPendingSelectionIds([nodeId])
     setPendingFocusNodeId(nodeId)

--- a/lib/ids-client-validation.ts
+++ b/lib/ids-client-validation.ts
@@ -6,6 +6,10 @@ export interface ValidationIssue {
     message: string
     nodeId?: string
     nodeType?: string
+    // The specific data field this issue is about (e.g. 'dataType', 'baseName').
+    // Lets the inspector ring the exact control that needs fixing. Omitted for
+    // node-level issues that don't map to a single field.
+    field?: string
 }
 
 export interface ClientValidationResult {
@@ -58,6 +62,7 @@ export async function validateGraphClientSide(
                     message: `Invalid IFC data type "${data.dataType}" in property "${data.baseName || 'unnamed'}"`,
                     nodeId: node.id,
                     nodeType: 'property',
+                    field: 'dataType',
                 })
             }
         }
@@ -71,6 +76,7 @@ export async function validateGraphClientSide(
                     message: `Property "${data.baseName}" should have data type ${validation.expectedTypes.join(' or ')}, not "${data.dataType}"`,
                     nodeId: node.id,
                     nodeType: 'property',
+                    field: 'dataType',
                 })
             }
         }
@@ -82,6 +88,7 @@ export async function validateGraphClientSide(
                 message: `Property node is missing propertySet`,
                 nodeId: node.id,
                 nodeType: 'property',
+                field: 'propertySet',
             })
         }
 
@@ -91,6 +98,7 @@ export async function validateGraphClientSide(
                 message: `Property node is missing baseName`,
                 nodeId: node.id,
                 nodeType: 'property',
+                field: 'baseName',
             })
         }
     }
@@ -105,6 +113,7 @@ export async function validateGraphClientSide(
                 message: 'Entity node is missing name',
                 nodeId: node.id,
                 nodeType: 'entity',
+                field: 'name',
             })
         }
     }


### PR DESCRIPTION
Closes #45.

Audit/validation errors were shown but couldn't be traced back to the graph, so large invalid IDS files (e.g. a Bane NOR IDS imported from another tool with 54 wrong property data types) were impractical to fix. The data needed to navigate already existed — every client-side `ValidationIssue` carries its `nodeId` — the UI just discarded it. This threads it through and builds the interaction on top.

## What changed

**Click an error → jump to its node**
- Error rows in the canvas overlay **and** the inspector issue list are now clickable. Clicking centers + zooms the canvas onto the node (`fitView`, `maxZoom 1.3`, animated) and selects it so the inspector opens on it.
- Implemented with a `pendingFocus` request consumed inside the `ReactFlowProvider`, mirroring the existing `pendingSelection` pattern. A stale-id guard makes a click on an already-deleted node a safe no-op.
- Parser-level errors (`@ifc-lite/ids` structure failures) have no node mapping and remain non-clickable by design.

**Highlight the exact field that needs fixing**
- Added an optional `field` to `ValidationIssue` (`dataType` / `baseName` / `propertySet` / `name`). The inspector rings the offending control red with the message inline, and the field scroll-flashes into view on click. Wired via a small `FieldIssueContext` so the eight `*Fields` components don't each thread props.
- The inspector issue list is split into **"On this node"** vs **"Elsewhere"**, the latter clickable to navigate.

**Spot problems on the canvas at a glance**
- Error/warning nodes get a red/amber ring (a `className` on the ReactFlow node wrapper + CSS — no edits to the node components) and error nodes are tinted red in the minimap.

## Verification
- Reproduced the issue by importing/seeding an invalid graph (wrong property data types) and confirmed end-to-end in a real browser: clicking an error from both the overlay and the inspector zooms+selects the node, rings its Data Type field with the correct message, and shows red node/minimap markers.
- `next build` passes (all 18 routes prerender); the changed code is TypeScript-clean.

## Notes
- 6 files changed, additive. No dependency or API changes.
- Behavior is unchanged when `onIssueSelect` isn't provided, so the components stay drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click validation issues to locate and center the related canvas node; issues with field info jump to that field in the inspector.
  * Inspector groups issues into "On this node" and "Elsewhere" and shows inline severity messages per field.
  * Minimap and node visuals prioritize selection and surface nodes with validation errors/warnings.

* **Style**
  * New boxed glow and one-shot field-flash highlight animations for nodes and focused fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->