### PR TITLE
Fix footer name typo: Trümper → Trümpler

### DIFF
--- a/components/app-footer.tsx
+++ b/components/app-footer.tsx
@@ -68,10 +68,10 @@ export function AppFooter() {
             href="https://www.linkedin.com/in/louistrue"
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="Visit Louis Trümper's LinkedIn profile"
+            aria-label="Visit Louis Trümpler's LinkedIn profile"
             className="hidden lg:inline transition-colors hover:text-primary hover:underline"
           >
-            Louis Trümper
+            Louis Trümpler
           </Link>
         </div>
 


### PR DESCRIPTION
Corrects the misspelled name in the app footer from "Louis Trümper" to "Louis Trümpler" — both the visible link text and the LinkedIn `aria-label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected name spelling in the footer LinkedIn link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->