### PR TITLE
Accept valid IFC measure subtypes in datatype validation (#48, #52)

### DIFF
--- a/lib/generated/ifc-schema/simple-types-ifc2x3.json
+++ b/lib/generated/ifc-schema/simple-types-ifc2x3.json
@@ -1,243 +1,8 @@
 [
   {
-    "name": "IFCLABEL",
-    "baseType": "xs:string",
-    "description": "Short text string (max 255 characters)"
-  },
-  {
-    "name": "IFCTEXT",
-    "baseType": "xs:string",
-    "description": "Long text string"
-  },
-  {
-    "name": "IFCBOOLEAN",
-    "baseType": "xs:boolean",
-    "description": "True or False value"
-  },
-  {
-    "name": "IFCINTEGER",
-    "baseType": "xs:integer",
-    "description": "Whole number"
-  },
-  {
-    "name": "IFCREAL",
+    "name": "IFCABSORBEDDOSEMEASURE",
     "baseType": "xs:double",
-    "description": "Decimal number"
-  },
-  {
-    "name": "IFCIDENTIFIER",
-    "baseType": "xs:string",
-    "description": "Unique identifier string"
-  },
-  {
-    "name": "IFCLOGICAL",
-    "baseType": "xs:string",
-    "description": "True, False, or Unknown"
-  },
-  {
-    "name": "IFCDATETIME",
-    "baseType": "xs:dateTime",
-    "description": "Date and time value"
-  },
-  {
-    "name": "IFCDATE",
-    "baseType": "xs:date",
-    "description": "Date value"
-  },
-  {
-    "name": "IFCTIME",
-    "baseType": "xs:time",
-    "description": "Time value"
-  },
-  {
-    "name": "IFCDURATION",
-    "baseType": "xs:duration",
-    "description": "Time duration"
-  },
-  {
-    "name": "IFCLENGTHMEASURE",
-    "baseType": "xs:double",
-    "description": "Length measurement"
-  },
-  {
-    "name": "IFCAREAMEASURE",
-    "baseType": "xs:double",
-    "description": "Area measurement"
-  },
-  {
-    "name": "IFCVOLUMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volume measurement"
-  },
-  {
-    "name": "IFCPLANEANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Plane angle measurement"
-  },
-  {
-    "name": "IFCSOLIDANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Solid angle measurement"
-  },
-  {
-    "name": "IFCMASSMEASURE",
-    "baseType": "xs:double",
-    "description": "Mass measurement"
-  },
-  {
-    "name": "IFCPOWERMEASURE",
-    "baseType": "xs:double",
-    "description": "Power measurement"
-  },
-  {
-    "name": "IFCPRESSUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Pressure measurement"
-  },
-  {
-    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal transmittance measurement"
-  },
-  {
-    "name": "IFCENERGYCONVERSIONRATE",
-    "baseType": "xs:double",
-    "description": "Energy conversion rate"
-  },
-  {
-    "name": "IFCTEMPERATUREGRADIENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Temperature gradient measurement"
-  },
-  {
-    "name": "IFCHEATINGVALUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Heating value measurement"
-  },
-  {
-    "name": "IFCTHERMOCONDUCTIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal conductivity measurement"
-  },
-  {
-    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volumetric flow rate measurement"
-  },
-  {
-    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Moisture diffusivity measurement"
-  },
-  {
-    "name": "IFCVAPORPERMEABILITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Vapor permeability measurement"
-  },
-  {
-    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Isothermal moisture capacity measurement"
-  },
-  {
-    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Specific heat capacity measurement"
-  },
-  {
-    "name": "IFCMONETARYMEASURE",
-    "baseType": "xs:double",
-    "description": "Monetary measurement"
-  },
-  {
-    "name": "IFCCOUNTMEASURE",
-    "baseType": "xs:integer",
-    "description": "Count measurement"
-  },
-  {
-    "name": "IFCTIMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Time measurement"
-  },
-  {
-    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermodynamic temperature measurement"
-  },
-  {
-    "name": "IFCPHMEASURE",
-    "baseType": "xs:double",
-    "description": "pH measurement"
-  },
-  {
-    "name": "IFCFREQUENCYMEASURE",
-    "baseType": "xs:double",
-    "description": "Frequency measurement"
-  },
-  {
-    "name": "IFCILLUMINANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Illuminance measurement"
-  },
-  {
-    "name": "IFCLUMINOUSFLUXMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous flux measurement"
-  },
-  {
-    "name": "IFCLUMINOUSINTENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous intensity measurement"
-  },
-  {
-    "name": "IFCELECTRICVOLTAGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric voltage measurement"
-  },
-  {
-    "name": "IFCELECTRICCURRENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric current measurement"
-  },
-  {
-    "name": "IFCELECTRICCHARGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric charge measurement"
-  },
-  {
-    "name": "IFCELECTRICRESISTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric resistance measurement"
-  },
-  {
-    "name": "IFCELECTRICCONDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric conductance measurement"
-  },
-  {
-    "name": "IFCELECTRICCAPACITANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric capacitance measurement"
-  },
-  {
-    "name": "IFCINDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Inductance measurement"
-  },
-  {
-    "name": "IFCFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Force measurement"
-  },
-  {
-    "name": "IFCMOMENTOFINERTIAMEASURE",
-    "baseType": "xs:double",
-    "description": "Moment of inertia measurement"
-  },
-  {
-    "name": "IFCTORQUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Torque measurement"
+    "description": "Measure value (decimal)"
   },
   {
     "name": "IFCACCELERATIONMEASURE",
@@ -245,9 +10,59 @@
     "description": "Acceleration measurement"
   },
   {
-    "name": "IFCLINEARVELOCITYMEASURE",
+    "name": "IFCACTIONSOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTUATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCADDRESSTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTOAIRHEATRECOVERYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALARMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAMOUNTOFSUBSTANCEMEASURE",
     "baseType": "xs:double",
-    "description": "Linear velocity measurement"
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCANALYSISMODELTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCANALYSISTHEORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCANGULARVELOCITYMEASURE",
@@ -255,44 +70,559 @@
     "description": "Angular velocity measurement"
   },
   {
+    "name": "IFCAREAMEASURE",
+    "baseType": "xs:double",
+    "description": "Area measurement"
+  },
+  {
+    "name": "IFCARITHMETICOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCASSEMBLYPLACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBENCHMARKENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBOILERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBOOLEAN",
+    "baseType": "xs:boolean",
+    "description": "True or False value"
+  },
+  {
+    "name": "IFCBOXALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPROXYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHANGEACTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHILLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOLUMNTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPRESSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONDENSERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRAINTENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONTEXTDEPENDENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCONTROLLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLEDBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLINGTOWERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOUNTMEASURE",
+    "baseType": "xs:integer",
+    "description": "Count measurement"
+  },
+  {
+    "name": "IFCCOVERINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURRENCYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURTAINWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURVATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCDAMPERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATAORIGINENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDAYINMONTHNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDAYLIGHTSAVINGHOUR",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDERIVEDUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDESCRIPTIVEMEASURE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCDIMENSIONCOUNT",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDIRECTIONSENSEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONCHAMBERELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTCONFIDENTIALITYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTSTATUSENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORSTYLECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORSTYLEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOSEEQUIVALENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCDUCTFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSILENCERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDYNAMICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCELECTRICAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICCAPACITANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric capacitance measurement"
+  },
+  {
+    "name": "IFCELECTRICCHARGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric charge measurement"
+  },
+  {
+    "name": "IFCELECTRICCONDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric conductance measurement"
+  },
+  {
+    "name": "IFCELECTRICCURRENTENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICCURRENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric current measurement"
+  },
+  {
+    "name": "IFCELECTRICDISTRIBUTIONPOINTFUNCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICFLOWSTORAGEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICGENERATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICHEATERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICMOTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric resistance measurement"
+  },
+  {
+    "name": "IFCELECTRICTIMECONTROLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICVOLTAGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric voltage measurement"
+  },
+  {
+    "name": "IFCELEMENTASSEMBLYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELEMENTCOMPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCENERGYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCENERGYSEQUENCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCENVIRONMENTALIMPACTCATEGORYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATIVECOOLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFILTERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFIRESUPPRESSIONTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWINSTRUMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWMETERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFONTSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTVARIANT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTWEIGHT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFOOTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Force measurement"
+  },
+  {
+    "name": "IFCFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Frequency measurement"
+  },
+  {
+    "name": "IFCGASTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOMETRICPROJECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGLOBALLYUNIQUEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCGLOBALORLOCALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATEXCHANGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCHEATINGVALUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Heating value measurement"
+  },
+  {
+    "name": "IFCHOURINDAY",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCHUMIDIFIERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIDENTIFIER",
+    "baseType": "xs:string",
+    "description": "Unique identifier string"
+  },
+  {
+    "name": "IFCILLUMINANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Illuminance measurement"
+  },
+  {
+    "name": "IFCINDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Inductance measurement"
+  },
+  {
+    "name": "IFCINTEGER",
+    "baseType": "xs:integer",
+    "description": "Whole number"
+  },
+  {
+    "name": "IFCINTEGERCOUNTRATEMEASURE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCINTERNALOREXTERNALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINVENTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIONCONCENTRATIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Isothermal moisture capacity measurement"
+  },
+  {
+    "name": "IFCJUNCTIONBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCKINEMATICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLABEL",
+    "baseType": "xs:string",
+    "description": "Short text string (max 255 characters)"
+  },
+  {
+    "name": "IFCLAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLAYERSETDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Length measurement"
+  },
+  {
+    "name": "IFCLIGHTDISTRIBUTIONCURVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTEMISSIONSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTFIXTURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
     "name": "IFCLINEARFORCEMEASURE",
     "baseType": "xs:double",
     "description": "Linear force measurement"
-  },
-  {
-    "name": "IFCPLANARFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Planar force measurement"
-  },
-  {
-    "name": "IFCLINEARSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear stiffness measurement"
-  },
-  {
-    "name": "IFCROTATIONALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Rotational stiffness measurement"
-  },
-  {
-    "name": "IFCWARPINGMOMENTALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Warping momental stiffness measurement"
-  },
-  {
-    "name": "IFCMODULUSOFELASTICITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Modulus of elasticity measurement"
-  },
-  {
-    "name": "IFCSHEARMODULUSMEASURE",
-    "baseType": "xs:double",
-    "description": "Shear modulus measurement"
-  },
-  {
-    "name": "IFCLINEARDENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear density measurement"
   },
   {
     "name": "IFCLINEARMOMENTMEASURE",
@@ -300,14 +630,384 @@
     "description": "Linear moment measurement"
   },
   {
-    "name": "IFCPLANARMOMENTMEASURE",
+    "name": "IFCLINEARSTIFFNESSMEASURE",
     "baseType": "xs:double",
-    "description": "Planar moment measurement"
+    "description": "Linear stiffness measurement"
   },
   {
-    "name": "IFCSECTIONMODULUSMEASURE",
+    "name": "IFCLINEARVELOCITYMEASURE",
     "baseType": "xs:double",
-    "description": "Section modulus measurement"
+    "description": "Linear velocity measurement"
+  },
+  {
+    "name": "IFCLOADGROUPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLOGICAL",
+    "baseType": "xs:string",
+    "description": "True, False, or Unknown"
+  },
+  {
+    "name": "IFCLOGICALOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLUMINOUSFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous flux measurement"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYDISTRIBUTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous intensity measurement"
+  },
+  {
+    "name": "IFCMAGNETICFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMAGNETICFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Mass measurement"
+  },
+  {
+    "name": "IFCMASSPERLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMINUTEINHOUR",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCMODULUSOFELASTICITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Modulus of elasticity measurement"
+  },
+  {
+    "name": "IFCMODULUSOFLINEARSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFROTATIONALSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Moisture diffusivity measurement"
+  },
+  {
+    "name": "IFCMOLECULARWEIGHTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOMENTOFINERTIAMEASURE",
+    "baseType": "xs:double",
+    "description": "Moment of inertia measurement"
+  },
+  {
+    "name": "IFCMONETARYMEASURE",
+    "baseType": "xs:double",
+    "description": "Monetary measurement"
+  },
+  {
+    "name": "IFCMONTHINYEARNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCMOTORCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCNORMALISEDRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNULLSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCNUMERICMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCOBJECTIVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOBJECTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOCCUPANTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOUTLETTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPARAMETERVALUE",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCPERMEABLECOVERINGOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPHMEASURE",
+    "baseType": "xs:double",
+    "description": "pH measurement"
+  },
+  {
+    "name": "IFCPHYSICALORVIRTUALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPLANARFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Planar force measurement"
+  },
+  {
+    "name": "IFCPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Plane angle measurement"
+  },
+  {
+    "name": "IFCPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPOSITIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVEPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVERATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Power measurement"
+  },
+  {
+    "name": "IFCPRESENTABLETEXT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Pressure measurement"
+  },
+  {
+    "name": "IFCPROCEDURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROFILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTEDORTRUELENGTHENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTORDERRECORDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTORDERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROPERTYSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPUMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRADIOACTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCRAILINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCREAL",
+    "baseType": "xs:double",
+    "description": "Decimal number"
+  },
+  {
+    "name": "IFCREFLECTANCEMETHODENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARSURFACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRESOURCECONSUMPTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRIBPLATEDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROOFTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROTATIONALFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALSTIFFNESSMEASURE",
+    "baseType": "xs:double",
+    "description": "Rotational stiffness measurement"
+  },
+  {
+    "name": "IFCSANITARYTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSECONDINMINUTE",
+    "baseType": "xs:double",
+    "description": "Decimal value"
   },
   {
     "name": "IFCSECTIONALAREAINTEGRALMEASURE",
@@ -315,8 +1015,333 @@
     "description": "Sectional area integral measurement"
   },
   {
-    "name": "IFCWARPING",
+    "name": "IFCSECTIONMODULUSMEASURE",
     "baseType": "xs:double",
-    "description": "Warping measurement"
+    "description": "Section modulus measurement"
+  },
+  {
+    "name": "IFCSECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSENSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSEQUENCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSERVICELIFEFACTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSERVICELIFETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHEARMODULUSMEASURE",
+    "baseType": "xs:double",
+    "description": "Shear modulus measurement"
+  },
+  {
+    "name": "IFCSLABTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLIDANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Solid angle measurement"
+  },
+  {
+    "name": "IFCSOUNDPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDSCALEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPACEHEATERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPACETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Specific heat capacity measurement"
+  },
+  {
+    "name": "IFCSPECULAREXPONENT",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSPECULARROUGHNESS",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSTACKTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTATEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSURFACETEXTUREENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSWITCHINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTANKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEMPERATUREGRADIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Temperature gradient measurement"
+  },
+  {
+    "name": "IFCTENDONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEXT",
+    "baseType": "xs:string",
+    "description": "Long text string"
+  },
+  {
+    "name": "IFCTEXTALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTDECORATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTFONTNAME",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTTRANSFORMATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTHERMALADMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALCONDUCTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALEXPANSIONCOEFFICIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALLOADSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTHERMALLOADTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTHERMALRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermal transmittance measurement"
+  },
+  {
+    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermodynamic temperature measurement"
+  },
+  {
+    "name": "IFCTIMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Time measurement"
+  },
+  {
+    "name": "IFCTIMESERIESDATATYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTIMESERIESSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTIMESTAMP",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCTORQUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Torque measurement"
+  },
+  {
+    "name": "IFCTRANSFORMERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTRANSPORTELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTUBEBUNDLETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYEQUIPMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVALVETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVAPORPERMEABILITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Vapor permeability measurement"
+  },
+  {
+    "name": "IFCVIBRATIONISOLATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOLUMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volume measurement"
+  },
+  {
+    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volumetric flow rate measurement"
+  },
+  {
+    "name": "IFCWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWARPINGCONSTANTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWARPINGMOMENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWASTETERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWSTYLECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWSTYLEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKCONTROLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCYEARNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
   }
 ]

--- a/lib/generated/ifc-schema/simple-types-ifc4.json
+++ b/lib/generated/ifc-schema/simple-types-ifc4.json
@@ -1,243 +1,8 @@
 [
   {
-    "name": "IFCLABEL",
-    "baseType": "xs:string",
-    "description": "Short text string (max 255 characters)"
-  },
-  {
-    "name": "IFCTEXT",
-    "baseType": "xs:string",
-    "description": "Long text string"
-  },
-  {
-    "name": "IFCBOOLEAN",
-    "baseType": "xs:boolean",
-    "description": "True or False value"
-  },
-  {
-    "name": "IFCINTEGER",
-    "baseType": "xs:integer",
-    "description": "Whole number"
-  },
-  {
-    "name": "IFCREAL",
+    "name": "IFCABSORBEDDOSEMEASURE",
     "baseType": "xs:double",
-    "description": "Decimal number"
-  },
-  {
-    "name": "IFCIDENTIFIER",
-    "baseType": "xs:string",
-    "description": "Unique identifier string"
-  },
-  {
-    "name": "IFCLOGICAL",
-    "baseType": "xs:string",
-    "description": "True, False, or Unknown"
-  },
-  {
-    "name": "IFCDATETIME",
-    "baseType": "xs:dateTime",
-    "description": "Date and time value"
-  },
-  {
-    "name": "IFCDATE",
-    "baseType": "xs:date",
-    "description": "Date value"
-  },
-  {
-    "name": "IFCTIME",
-    "baseType": "xs:time",
-    "description": "Time value"
-  },
-  {
-    "name": "IFCDURATION",
-    "baseType": "xs:duration",
-    "description": "Time duration"
-  },
-  {
-    "name": "IFCLENGTHMEASURE",
-    "baseType": "xs:double",
-    "description": "Length measurement"
-  },
-  {
-    "name": "IFCAREAMEASURE",
-    "baseType": "xs:double",
-    "description": "Area measurement"
-  },
-  {
-    "name": "IFCVOLUMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volume measurement"
-  },
-  {
-    "name": "IFCPLANEANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Plane angle measurement"
-  },
-  {
-    "name": "IFCSOLIDANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Solid angle measurement"
-  },
-  {
-    "name": "IFCMASSMEASURE",
-    "baseType": "xs:double",
-    "description": "Mass measurement"
-  },
-  {
-    "name": "IFCPOWERMEASURE",
-    "baseType": "xs:double",
-    "description": "Power measurement"
-  },
-  {
-    "name": "IFCPRESSUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Pressure measurement"
-  },
-  {
-    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal transmittance measurement"
-  },
-  {
-    "name": "IFCENERGYCONVERSIONRATE",
-    "baseType": "xs:double",
-    "description": "Energy conversion rate"
-  },
-  {
-    "name": "IFCTEMPERATUREGRADIENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Temperature gradient measurement"
-  },
-  {
-    "name": "IFCHEATINGVALUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Heating value measurement"
-  },
-  {
-    "name": "IFCTHERMOCONDUCTIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal conductivity measurement"
-  },
-  {
-    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volumetric flow rate measurement"
-  },
-  {
-    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Moisture diffusivity measurement"
-  },
-  {
-    "name": "IFCVAPORPERMEABILITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Vapor permeability measurement"
-  },
-  {
-    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Isothermal moisture capacity measurement"
-  },
-  {
-    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Specific heat capacity measurement"
-  },
-  {
-    "name": "IFCMONETARYMEASURE",
-    "baseType": "xs:double",
-    "description": "Monetary measurement"
-  },
-  {
-    "name": "IFCCOUNTMEASURE",
-    "baseType": "xs:integer",
-    "description": "Count measurement"
-  },
-  {
-    "name": "IFCTIMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Time measurement"
-  },
-  {
-    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermodynamic temperature measurement"
-  },
-  {
-    "name": "IFCPHMEASURE",
-    "baseType": "xs:double",
-    "description": "pH measurement"
-  },
-  {
-    "name": "IFCFREQUENCYMEASURE",
-    "baseType": "xs:double",
-    "description": "Frequency measurement"
-  },
-  {
-    "name": "IFCILLUMINANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Illuminance measurement"
-  },
-  {
-    "name": "IFCLUMINOUSFLUXMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous flux measurement"
-  },
-  {
-    "name": "IFCLUMINOUSINTENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous intensity measurement"
-  },
-  {
-    "name": "IFCELECTRICVOLTAGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric voltage measurement"
-  },
-  {
-    "name": "IFCELECTRICCURRENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric current measurement"
-  },
-  {
-    "name": "IFCELECTRICCHARGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric charge measurement"
-  },
-  {
-    "name": "IFCELECTRICRESISTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric resistance measurement"
-  },
-  {
-    "name": "IFCELECTRICCONDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric conductance measurement"
-  },
-  {
-    "name": "IFCELECTRICCAPACITANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric capacitance measurement"
-  },
-  {
-    "name": "IFCINDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Inductance measurement"
-  },
-  {
-    "name": "IFCFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Force measurement"
-  },
-  {
-    "name": "IFCMOMENTOFINERTIAMEASURE",
-    "baseType": "xs:double",
-    "description": "Moment of inertia measurement"
-  },
-  {
-    "name": "IFCTORQUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Torque measurement"
+    "description": "Measure value (decimal)"
   },
   {
     "name": "IFCACCELERATIONMEASURE",
@@ -245,9 +10,64 @@
     "description": "Acceleration measurement"
   },
   {
-    "name": "IFCLINEARVELOCITYMEASURE",
+    "name": "IFCACTIONREQUESTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONSOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTUATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCADDRESSTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTOAIRHEATRECOVERYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALARMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAMOUNTOFSUBSTANCEMEASURE",
     "baseType": "xs:double",
-    "description": "Linear velocity measurement"
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCANALYSISMODELTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCANALYSISTHEORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCANGULARVELOCITYMEASURE",
@@ -255,44 +75,704 @@
     "description": "Angular velocity measurement"
   },
   {
+    "name": "IFCAREADENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCAREAMEASURE",
+    "baseType": "xs:double",
+    "description": "Area measurement"
+  },
+  {
+    "name": "IFCARITHMETICOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCASSEMBLYPLACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAUDIOVISUALAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBENCHMARKENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBINARY",
+    "baseType": "",
+    "description": "Binary value"
+  },
+  {
+    "name": "IFCBOILERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBOOLEAN",
+    "baseType": "xs:boolean",
+    "description": "True or False value"
+  },
+  {
+    "name": "IFCBOXALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPROXYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGSYSTEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBURNERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCARDINALPOINTREFERENCE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCCHANGEACTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHILLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHIMNEYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOLUMNTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMMUNICATIONSAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPLEXPROPERTYTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPRESSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONDENSERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRAINTENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONEQUIPMENTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONMATERIALRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONPRODUCTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONTEXTDEPENDENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCONTROLLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLEDBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLINGTOWERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTITEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOUNTMEASURE",
+    "baseType": "xs:integer",
+    "description": "Count measurement"
+  },
+  {
+    "name": "IFCCOVERINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCREWRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURTAINWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURVATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCURVEINTERPOLATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDAMPERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATAORIGINENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATE",
+    "baseType": "xs:date",
+    "description": "Date value"
+  },
+  {
+    "name": "IFCDATETIME",
+    "baseType": "xs:dateTime",
+    "description": "Date and time value"
+  },
+  {
+    "name": "IFCDAYINMONTHNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDAYINWEEKNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDERIVEDUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDESCRIPTIVEMEASURE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCDIMENSIONCOUNT",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDIRECTIONSENSEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISCRETEACCESSORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONCHAMBERELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONPORTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONSYSTEMENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTCONFIDENTIALITYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTSTATUSENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORSTYLECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORSTYLEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORTYPEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOSEEQUIVALENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCDUCTFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSILENCERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDURATION",
+    "baseType": "xs:duration",
+    "description": "Time duration"
+  },
+  {
+    "name": "IFCDYNAMICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCELECTRICAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICCAPACITANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric capacitance measurement"
+  },
+  {
+    "name": "IFCELECTRICCHARGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric charge measurement"
+  },
+  {
+    "name": "IFCELECTRICCONDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric conductance measurement"
+  },
+  {
+    "name": "IFCELECTRICCURRENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric current measurement"
+  },
+  {
+    "name": "IFCELECTRICDISTRIBUTIONBOARDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICFLOWSTORAGEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICGENERATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICMOTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric resistance measurement"
+  },
+  {
+    "name": "IFCELECTRICTIMECONTROLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICVOLTAGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric voltage measurement"
+  },
+  {
+    "name": "IFCELEMENTASSEMBLYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELEMENTCOMPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCENERGYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCENGINETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATIVECOOLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVENTTRIGGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEXTERNALSPATIALELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFASTENERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFILTERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFIRESUPPRESSIONTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWINSTRUMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWMETERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFONTSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTVARIANT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTWEIGHT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFOOTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Force measurement"
+  },
+  {
+    "name": "IFCFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Frequency measurement"
+  },
+  {
+    "name": "IFCFURNITURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOGRAPHICELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOMETRICPROJECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGLOBALLYUNIQUEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCGLOBALORLOCALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGRIDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATEXCHANGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCHEATINGVALUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Heating value measurement"
+  },
+  {
+    "name": "IFCHUMIDIFIERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIDENTIFIER",
+    "baseType": "xs:string",
+    "description": "Unique identifier string"
+  },
+  {
+    "name": "IFCILLUMINANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Illuminance measurement"
+  },
+  {
+    "name": "IFCINDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Inductance measurement"
+  },
+  {
+    "name": "IFCINTEGER",
+    "baseType": "xs:integer",
+    "description": "Whole number"
+  },
+  {
+    "name": "IFCINTEGERCOUNTRATEMEASURE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCINTERCEPTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINTERNALOREXTERNALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINVENTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIONCONCENTRATIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Isothermal moisture capacity measurement"
+  },
+  {
+    "name": "IFCJUNCTIONBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCKINEMATICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLABEL",
+    "baseType": "xs:string",
+    "description": "Short text string (max 255 characters)"
+  },
+  {
+    "name": "IFCLABORRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLANGUAGEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCLAYERSETDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Length measurement"
+  },
+  {
+    "name": "IFCLIGHTDISTRIBUTIONCURVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTEMISSIONSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTFIXTURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
     "name": "IFCLINEARFORCEMEASURE",
     "baseType": "xs:double",
     "description": "Linear force measurement"
-  },
-  {
-    "name": "IFCPLANARFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Planar force measurement"
-  },
-  {
-    "name": "IFCLINEARSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear stiffness measurement"
-  },
-  {
-    "name": "IFCROTATIONALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Rotational stiffness measurement"
-  },
-  {
-    "name": "IFCWARPINGMOMENTALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Warping momental stiffness measurement"
-  },
-  {
-    "name": "IFCMODULUSOFELASTICITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Modulus of elasticity measurement"
-  },
-  {
-    "name": "IFCSHEARMODULUSMEASURE",
-    "baseType": "xs:double",
-    "description": "Shear modulus measurement"
-  },
-  {
-    "name": "IFCLINEARDENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear density measurement"
   },
   {
     "name": "IFCLINEARMOMENTMEASURE",
@@ -300,14 +780,424 @@
     "description": "Linear moment measurement"
   },
   {
-    "name": "IFCPLANARMOMENTMEASURE",
+    "name": "IFCLINEARSTIFFNESSMEASURE",
     "baseType": "xs:double",
-    "description": "Planar moment measurement"
+    "description": "Linear stiffness measurement"
   },
   {
-    "name": "IFCSECTIONMODULUSMEASURE",
+    "name": "IFCLINEARVELOCITYMEASURE",
     "baseType": "xs:double",
-    "description": "Section modulus measurement"
+    "description": "Linear velocity measurement"
+  },
+  {
+    "name": "IFCLOADGROUPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLOGICAL",
+    "baseType": "xs:string",
+    "description": "True, False, or Unknown"
+  },
+  {
+    "name": "IFCLOGICALOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLUMINOUSFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous flux measurement"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYDISTRIBUTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous intensity measurement"
+  },
+  {
+    "name": "IFCMAGNETICFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMAGNETICFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Mass measurement"
+  },
+  {
+    "name": "IFCMASSPERLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMECHANICALFASTENERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMEDICALDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMODULUSOFELASTICITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Modulus of elasticity measurement"
+  },
+  {
+    "name": "IFCMODULUSOFLINEARSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFROTATIONALSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Moisture diffusivity measurement"
+  },
+  {
+    "name": "IFCMOLECULARWEIGHTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOMENTOFINERTIAMEASURE",
+    "baseType": "xs:double",
+    "description": "Moment of inertia measurement"
+  },
+  {
+    "name": "IFCMONETARYMEASURE",
+    "baseType": "xs:double",
+    "description": "Monetary measurement"
+  },
+  {
+    "name": "IFCMONTHINYEARNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCMOTORCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCNONNEGATIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNORMALISEDRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNULLSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCNUMERICMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCOBJECTIVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOBJECTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOCCUPANTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOPENINGELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOUTLETTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPARAMETERVALUE",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCPERFORMANCEHISTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERMEABLECOVERINGOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERMITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPHMEASURE",
+    "baseType": "xs:double",
+    "description": "pH measurement"
+  },
+  {
+    "name": "IFCPHYSICALORVIRTUALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPLANARFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Planar force measurement"
+  },
+  {
+    "name": "IFCPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Plane angle measurement"
+  },
+  {
+    "name": "IFCPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPOSITIVEINTEGER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCPOSITIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVEPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVERATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Power measurement"
+  },
+  {
+    "name": "IFCPRESENTABLETEXT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Pressure measurement"
+  },
+  {
+    "name": "IFCPROCEDURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROFILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTEDORTRUELENGTHENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTIONELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTORDERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROPERTYSETTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETRIPPINGUNITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPUMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRADIOACTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCRAILINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCREAL",
+    "baseType": "xs:double",
+    "description": "Decimal number"
+  },
+  {
+    "name": "IFCRECURRENCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREFERENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREFLECTANCEMETHODENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARSURFACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGMESHTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROOFTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROTATIONALFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALSTIFFNESSMEASURE",
+    "baseType": "xs:double",
+    "description": "Rotational stiffness measurement"
+  },
+  {
+    "name": "IFCSANITARYTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCSECTIONALAREAINTEGRALMEASURE",
@@ -315,8 +1205,413 @@
     "description": "Sectional area integral measurement"
   },
   {
-    "name": "IFCWARPING",
+    "name": "IFCSECTIONMODULUSMEASURE",
     "baseType": "xs:double",
-    "description": "Warping measurement"
+    "description": "Section modulus measurement"
+  },
+  {
+    "name": "IFCSECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSENSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSEQUENCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHADINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHEARMODULUSMEASURE",
+    "baseType": "xs:double",
+    "description": "Shear modulus measurement"
+  },
+  {
+    "name": "IFCSIMPLEPROPERTYTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSLABTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLARDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLIDANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Solid angle measurement"
+  },
+  {
+    "name": "IFCSOUNDPOWERLEVELMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSURELEVELMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSPACEHEATERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPACETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPATIALZONETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Specific heat capacity measurement"
+  },
+  {
+    "name": "IFCSPECULAREXPONENT",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSPECULARROUGHNESS",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSTACKTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTATEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRIPPEDOPTIONAL",
+    "baseType": "xs:boolean",
+    "description": "Boolean value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVEACTIVITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVEMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACEACTIVITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACEMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSUBCONTRACTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSURFACEFEATURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSWITCHINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSYSTEMFURNITUREELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTANKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTASKDURATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTASKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEMPERATUREGRADIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Temperature gradient measurement"
+  },
+  {
+    "name": "IFCTEMPERATURERATEOFCHANGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTENDONANCHORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTENDONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEXT",
+    "baseType": "xs:string",
+    "description": "Long text string"
+  },
+  {
+    "name": "IFCTEXTALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTDECORATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTFONTNAME",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTTRANSFORMATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTHERMALADMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALCONDUCTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALEXPANSIONCOEFFICIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermal transmittance measurement"
+  },
+  {
+    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermodynamic temperature measurement"
+  },
+  {
+    "name": "IFCTIME",
+    "baseType": "xs:time",
+    "description": "Time value"
+  },
+  {
+    "name": "IFCTIMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Time measurement"
+  },
+  {
+    "name": "IFCTIMESERIESDATATYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTIMESTAMP",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCTORQUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Torque measurement"
+  },
+  {
+    "name": "IFCTRANSFORMERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTRANSPORTELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTUBEBUNDLETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYCONTROLELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYEQUIPMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCURIREFERENCE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCVALVETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVAPORPERMEABILITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Vapor permeability measurement"
+  },
+  {
+    "name": "IFCVIBRATIONISOLATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOIDINGFEATURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOLUMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volume measurement"
+  },
+  {
+    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volumetric flow rate measurement"
+  },
+  {
+    "name": "IFCWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWARPINGCONSTANTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWARPINGMOMENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWASTETERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWSTYLECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWSTYLEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWTYPEPARTITIONINGENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKCALENDARTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKPLANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   }
 ]

--- a/lib/generated/ifc-schema/simple-types-ifc4x3_add2.json
+++ b/lib/generated/ifc-schema/simple-types-ifc4x3_add2.json
@@ -1,243 +1,8 @@
 [
   {
-    "name": "IFCLABEL",
-    "baseType": "xs:string",
-    "description": "Short text string (max 255 characters)"
-  },
-  {
-    "name": "IFCTEXT",
-    "baseType": "xs:string",
-    "description": "Long text string"
-  },
-  {
-    "name": "IFCBOOLEAN",
-    "baseType": "xs:boolean",
-    "description": "True or False value"
-  },
-  {
-    "name": "IFCINTEGER",
-    "baseType": "xs:integer",
-    "description": "Whole number"
-  },
-  {
-    "name": "IFCREAL",
+    "name": "IFCABSORBEDDOSEMEASURE",
     "baseType": "xs:double",
-    "description": "Decimal number"
-  },
-  {
-    "name": "IFCIDENTIFIER",
-    "baseType": "xs:string",
-    "description": "Unique identifier string"
-  },
-  {
-    "name": "IFCLOGICAL",
-    "baseType": "xs:string",
-    "description": "True, False, or Unknown"
-  },
-  {
-    "name": "IFCDATETIME",
-    "baseType": "xs:dateTime",
-    "description": "Date and time value"
-  },
-  {
-    "name": "IFCDATE",
-    "baseType": "xs:date",
-    "description": "Date value"
-  },
-  {
-    "name": "IFCTIME",
-    "baseType": "xs:time",
-    "description": "Time value"
-  },
-  {
-    "name": "IFCDURATION",
-    "baseType": "xs:duration",
-    "description": "Time duration"
-  },
-  {
-    "name": "IFCLENGTHMEASURE",
-    "baseType": "xs:double",
-    "description": "Length measurement"
-  },
-  {
-    "name": "IFCAREAMEASURE",
-    "baseType": "xs:double",
-    "description": "Area measurement"
-  },
-  {
-    "name": "IFCVOLUMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volume measurement"
-  },
-  {
-    "name": "IFCPLANEANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Plane angle measurement"
-  },
-  {
-    "name": "IFCSOLIDANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Solid angle measurement"
-  },
-  {
-    "name": "IFCMASSMEASURE",
-    "baseType": "xs:double",
-    "description": "Mass measurement"
-  },
-  {
-    "name": "IFCPOWERMEASURE",
-    "baseType": "xs:double",
-    "description": "Power measurement"
-  },
-  {
-    "name": "IFCPRESSUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Pressure measurement"
-  },
-  {
-    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal transmittance measurement"
-  },
-  {
-    "name": "IFCENERGYCONVERSIONRATE",
-    "baseType": "xs:double",
-    "description": "Energy conversion rate"
-  },
-  {
-    "name": "IFCTEMPERATUREGRADIENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Temperature gradient measurement"
-  },
-  {
-    "name": "IFCHEATINGVALUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Heating value measurement"
-  },
-  {
-    "name": "IFCTHERMOCONDUCTIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal conductivity measurement"
-  },
-  {
-    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volumetric flow rate measurement"
-  },
-  {
-    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Moisture diffusivity measurement"
-  },
-  {
-    "name": "IFCVAPORPERMEABILITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Vapor permeability measurement"
-  },
-  {
-    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Isothermal moisture capacity measurement"
-  },
-  {
-    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Specific heat capacity measurement"
-  },
-  {
-    "name": "IFCMONETARYMEASURE",
-    "baseType": "xs:double",
-    "description": "Monetary measurement"
-  },
-  {
-    "name": "IFCCOUNTMEASURE",
-    "baseType": "xs:integer",
-    "description": "Count measurement"
-  },
-  {
-    "name": "IFCTIMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Time measurement"
-  },
-  {
-    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermodynamic temperature measurement"
-  },
-  {
-    "name": "IFCPHMEASURE",
-    "baseType": "xs:double",
-    "description": "pH measurement"
-  },
-  {
-    "name": "IFCFREQUENCYMEASURE",
-    "baseType": "xs:double",
-    "description": "Frequency measurement"
-  },
-  {
-    "name": "IFCILLUMINANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Illuminance measurement"
-  },
-  {
-    "name": "IFCLUMINOUSFLUXMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous flux measurement"
-  },
-  {
-    "name": "IFCLUMINOUSINTENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous intensity measurement"
-  },
-  {
-    "name": "IFCELECTRICVOLTAGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric voltage measurement"
-  },
-  {
-    "name": "IFCELECTRICCURRENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric current measurement"
-  },
-  {
-    "name": "IFCELECTRICCHARGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric charge measurement"
-  },
-  {
-    "name": "IFCELECTRICRESISTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric resistance measurement"
-  },
-  {
-    "name": "IFCELECTRICCONDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric conductance measurement"
-  },
-  {
-    "name": "IFCELECTRICCAPACITANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric capacitance measurement"
-  },
-  {
-    "name": "IFCINDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Inductance measurement"
-  },
-  {
-    "name": "IFCFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Force measurement"
-  },
-  {
-    "name": "IFCMOMENTOFINERTIAMEASURE",
-    "baseType": "xs:double",
-    "description": "Moment of inertia measurement"
-  },
-  {
-    "name": "IFCTORQUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Torque measurement"
+    "description": "Measure value (decimal)"
   },
   {
     "name": "IFCACCELERATIONMEASURE",
@@ -245,9 +10,84 @@
     "description": "Acceleration measurement"
   },
   {
-    "name": "IFCLINEARVELOCITYMEASURE",
+    "name": "IFCACTIONREQUESTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONSOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTUATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCADDRESSTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTOAIRHEATRECOVERYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALARMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALIGNMENTCANTSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALIGNMENTHORIZONTALSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALIGNMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALIGNMENTVERTICALSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAMOUNTOFSUBSTANCEMEASURE",
     "baseType": "xs:double",
-    "description": "Linear velocity measurement"
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCANALYSISMODELTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCANALYSISTHEORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCANGULARVELOCITYMEASURE",
@@ -255,44 +95,779 @@
     "description": "Angular velocity measurement"
   },
   {
+    "name": "IFCANNOTATIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAREADENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCAREAMEASURE",
+    "baseType": "xs:double",
+    "description": "Area measurement"
+  },
+  {
+    "name": "IFCARITHMETICOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCASSEMBLYPLACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAUDIOVISUALAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBEARINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBENCHMARKENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBINARY",
+    "baseType": "",
+    "description": "Binary value"
+  },
+  {
+    "name": "IFCBOILERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBOOLEAN",
+    "baseType": "xs:boolean",
+    "description": "True or False value"
+  },
+  {
+    "name": "IFCBOXALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCBRIDGEPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBRIDGETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPROXYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGSYSTEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILTSYSTEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBURNERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCAISSONFOUNDATIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCARDINALPOINTREFERENCE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCCHANGEACTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHILLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHIMNEYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOLUMNTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMMUNICATIONSAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPLEXPROPERTYTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPRESSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONDENSERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRAINTENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONEQUIPMENTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONMATERIALRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONPRODUCTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONTEXTDEPENDENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCONTROLLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONVEYORSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLEDBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLINGTOWERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTITEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOUNTMEASURE",
+    "baseType": "xs:integer",
+    "description": "Count measurement"
+  },
+  {
+    "name": "IFCCOURSETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOVERINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCREWRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURTAINWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURVATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCURVEINTERPOLATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDAMPERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATAORIGINENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATE",
+    "baseType": "xs:date",
+    "description": "Date value"
+  },
+  {
+    "name": "IFCDATETIME",
+    "baseType": "xs:dateTime",
+    "description": "Date and time value"
+  },
+  {
+    "name": "IFCDAYINMONTHNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDAYINWEEKNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDERIVEDUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDESCRIPTIVEMEASURE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCDIMENSIONCOUNT",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDIRECTIONSENSEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISCRETEACCESSORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONBOARDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONCHAMBERELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONPORTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONSYSTEMENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTCONFIDENTIALITYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTSTATUSENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORTYPEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOSEEQUIVALENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCDUCTFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSILENCERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDURATION",
+    "baseType": "xs:duration",
+    "description": "Time duration"
+  },
+  {
+    "name": "IFCDYNAMICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCEARTHWORKSCUTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEARTHWORKSFILLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICCAPACITANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric capacitance measurement"
+  },
+  {
+    "name": "IFCELECTRICCHARGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric charge measurement"
+  },
+  {
+    "name": "IFCELECTRICCONDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric conductance measurement"
+  },
+  {
+    "name": "IFCELECTRICCURRENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric current measurement"
+  },
+  {
+    "name": "IFCELECTRICDISTRIBUTIONBOARDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICFLOWSTORAGEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICFLOWTREATMENTDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICGENERATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICMOTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric resistance measurement"
+  },
+  {
+    "name": "IFCELECTRICTIMECONTROLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICVOLTAGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric voltage measurement"
+  },
+  {
+    "name": "IFCELEMENTASSEMBLYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELEMENTCOMPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCENERGYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCENGINETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATIVECOOLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVENTTRIGGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEXTERNALSPATIALELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFACILITYPARTCOMMONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFACILITYUSAGEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFASTENERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFILTERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFIRESUPPRESSIONTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWINSTRUMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWMETERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFONTSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTVARIANT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTWEIGHT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFOOTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Force measurement"
+  },
+  {
+    "name": "IFCFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Frequency measurement"
+  },
+  {
+    "name": "IFCFURNITURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOGRAPHICELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOMETRICPROJECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOTECHNICALSTRATUMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGLOBALLYUNIQUEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCGLOBALORLOCALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGRIDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATEXCHANGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCHEATINGVALUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Heating value measurement"
+  },
+  {
+    "name": "IFCHUMIDIFIERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIDENTIFIER",
+    "baseType": "xs:string",
+    "description": "Unique identifier string"
+  },
+  {
+    "name": "IFCILLUMINANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Illuminance measurement"
+  },
+  {
+    "name": "IFCIMPACTPROTECTIONDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Inductance measurement"
+  },
+  {
+    "name": "IFCINTEGER",
+    "baseType": "xs:integer",
+    "description": "Whole number"
+  },
+  {
+    "name": "IFCINTEGERCOUNTRATEMEASURE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCINTERCEPTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINTERNALOREXTERNALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINVENTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIONCONCENTRATIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Isothermal moisture capacity measurement"
+  },
+  {
+    "name": "IFCJUNCTIONBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCKERBTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCKINEMATICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLABEL",
+    "baseType": "xs:string",
+    "description": "Short text string (max 255 characters)"
+  },
+  {
+    "name": "IFCLABORRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLANGUAGEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCLAYERSETDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Length measurement"
+  },
+  {
+    "name": "IFCLIGHTDISTRIBUTIONCURVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTEMISSIONSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTFIXTURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
     "name": "IFCLINEARFORCEMEASURE",
     "baseType": "xs:double",
     "description": "Linear force measurement"
-  },
-  {
-    "name": "IFCPLANARFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Planar force measurement"
-  },
-  {
-    "name": "IFCLINEARSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear stiffness measurement"
-  },
-  {
-    "name": "IFCROTATIONALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Rotational stiffness measurement"
-  },
-  {
-    "name": "IFCWARPINGMOMENTALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Warping momental stiffness measurement"
-  },
-  {
-    "name": "IFCMODULUSOFELASTICITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Modulus of elasticity measurement"
-  },
-  {
-    "name": "IFCSHEARMODULUSMEASURE",
-    "baseType": "xs:double",
-    "description": "Shear modulus measurement"
-  },
-  {
-    "name": "IFCLINEARDENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear density measurement"
   },
   {
     "name": "IFCLINEARMOMENTMEASURE",
@@ -300,14 +875,479 @@
     "description": "Linear moment measurement"
   },
   {
-    "name": "IFCPLANARMOMENTMEASURE",
+    "name": "IFCLINEARSTIFFNESSMEASURE",
     "baseType": "xs:double",
-    "description": "Planar moment measurement"
+    "description": "Linear stiffness measurement"
   },
   {
-    "name": "IFCSECTIONMODULUSMEASURE",
+    "name": "IFCLINEARVELOCITYMEASURE",
     "baseType": "xs:double",
-    "description": "Section modulus measurement"
+    "description": "Linear velocity measurement"
+  },
+  {
+    "name": "IFCLIQUIDTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLOADGROUPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLOGICAL",
+    "baseType": "xs:string",
+    "description": "True, False, or Unknown"
+  },
+  {
+    "name": "IFCLOGICALOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLUMINOUSFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous flux measurement"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYDISTRIBUTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous intensity measurement"
+  },
+  {
+    "name": "IFCMAGNETICFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMAGNETICFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMARINEFACILITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMARINEPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMASSDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Mass measurement"
+  },
+  {
+    "name": "IFCMASSPERLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMECHANICALFASTENERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMEDICALDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMOBILETELECOMMUNICATIONSAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMODULUSOFELASTICITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Modulus of elasticity measurement"
+  },
+  {
+    "name": "IFCMODULUSOFLINEARSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFROTATIONALSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Moisture diffusivity measurement"
+  },
+  {
+    "name": "IFCMOLECULARWEIGHTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOMENTOFINERTIAMEASURE",
+    "baseType": "xs:double",
+    "description": "Moment of inertia measurement"
+  },
+  {
+    "name": "IFCMONETARYMEASURE",
+    "baseType": "xs:double",
+    "description": "Monetary measurement"
+  },
+  {
+    "name": "IFCMONTHINYEARNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCMOORINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMOTORCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCNAVIGATIONELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCNONNEGATIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNORMALISEDRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNUMERICMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCOBJECTIVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOCCUPANTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOPENINGELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOUTLETTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPARAMETERVALUE",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCPAVEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERFORMANCEHISTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERMEABLECOVERINGOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERMITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPHMEASURE",
+    "baseType": "xs:double",
+    "description": "pH measurement"
+  },
+  {
+    "name": "IFCPHYSICALORVIRTUALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPLANARFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Planar force measurement"
+  },
+  {
+    "name": "IFCPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Plane angle measurement"
+  },
+  {
+    "name": "IFCPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPOSITIVEINTEGER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCPOSITIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVEPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVERATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Power measurement"
+  },
+  {
+    "name": "IFCPRESENTABLETEXT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Pressure measurement"
+  },
+  {
+    "name": "IFCPROCEDURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROFILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTEDORTRUELENGTHENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTIONELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTORDERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROPERTYSETTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETRIPPINGUNITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPUMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRADIOACTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCRAILINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAILWAYPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAILWAYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCREAL",
+    "baseType": "xs:double",
+    "description": "Decimal number"
+  },
+  {
+    "name": "IFCRECURRENCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREFERENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREFLECTANCEMETHODENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCEDSOILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARSURFACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGMESHTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROADPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROADTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROOFTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROTATIONALFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALSTIFFNESSMEASURE",
+    "baseType": "xs:double",
+    "description": "Rotational stiffness measurement"
+  },
+  {
+    "name": "IFCSANITARYTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCSECTIONALAREAINTEGRALMEASURE",
@@ -315,8 +1355,443 @@
     "description": "Sectional area integral measurement"
   },
   {
-    "name": "IFCWARPING",
+    "name": "IFCSECTIONMODULUSMEASURE",
     "baseType": "xs:double",
-    "description": "Warping measurement"
+    "description": "Section modulus measurement"
+  },
+  {
+    "name": "IFCSECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSENSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSEQUENCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHADINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHEARMODULUSMEASURE",
+    "baseType": "xs:double",
+    "description": "Shear modulus measurement"
+  },
+  {
+    "name": "IFCSIGNALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSIGNTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSIMPLEPROPERTYTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSLABTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLARDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLIDANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Solid angle measurement"
+  },
+  {
+    "name": "IFCSOUNDPOWERLEVELMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSURELEVELMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSPACEHEATERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPACETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPATIALZONETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Specific heat capacity measurement"
+  },
+  {
+    "name": "IFCSPECULAREXPONENT",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSPECULARROUGHNESS",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSTACKTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTATEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRIPPEDOPTIONAL",
+    "baseType": "xs:boolean",
+    "description": "Boolean value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVEACTIVITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVEMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACEACTIVITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACEMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSUBCONTRACTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSURFACEFEATURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSWITCHINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSYSTEMFURNITUREELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTANKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTASKDURATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTASKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEMPERATUREGRADIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Temperature gradient measurement"
+  },
+  {
+    "name": "IFCTEMPERATURERATEOFCHANGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTENDONANCHORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTENDONCONDUITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTENDONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEXT",
+    "baseType": "xs:string",
+    "description": "Long text string"
+  },
+  {
+    "name": "IFCTEXTALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTDECORATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTFONTNAME",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTTRANSFORMATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTHERMALADMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALCONDUCTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALEXPANSIONCOEFFICIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermal transmittance measurement"
+  },
+  {
+    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermodynamic temperature measurement"
+  },
+  {
+    "name": "IFCTIME",
+    "baseType": "xs:time",
+    "description": "Time value"
+  },
+  {
+    "name": "IFCTIMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Time measurement"
+  },
+  {
+    "name": "IFCTIMESERIESDATATYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTIMESTAMP",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCTORQUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Torque measurement"
+  },
+  {
+    "name": "IFCTRACKELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTRANSFORMERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTRANSPORTELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTUBEBUNDLETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYCONTROLELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYEQUIPMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCURIREFERENCE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCVALVETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVAPORPERMEABILITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Vapor permeability measurement"
+  },
+  {
+    "name": "IFCVEHICLETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVIBRATIONDAMPERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVIBRATIONISOLATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVIRTUALELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOIDINGFEATURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOLUMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volume measurement"
+  },
+  {
+    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volumetric flow rate measurement"
+  },
+  {
+    "name": "IFCWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWARPINGCONSTANTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWARPINGMOMENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWASTETERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWELLKNOWNTEXTLITERAL",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCWINDOWPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWTYPEPARTITIONINGENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKCALENDARTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKPLANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   }
 ]

--- a/lib/ids-client-validation.ts
+++ b/lib/ids-client-validation.ts
@@ -43,10 +43,15 @@ export async function validateGraphClientSide(
         return { isValid: false, issues }
     }
 
-    // Build the property data-type cache so that isPropertyDataTypeValid()
-    // can detect semantic mismatches (e.g. LoadBearing ≠ IFCDATE).
-    // This is a no-op if the cache is already populated for this version.
-    await ensurePropertyDataTypeCache(ifcVersion)
+    // Build the property data-type cache (for template comparisons) AND the
+    // simple-type caches (the per-version list of valid IDS datatypes + their
+    // value categories) so that both the syntactic check (validateDataType) and
+    // the semantic check (isPropertyDataTypeValid) have version-correct data.
+    // These are no-ops if already populated for this version.
+    await Promise.all([
+        ensurePropertyDataTypeCache(ifcVersion),
+        getAllSimpleTypes(ifcVersion),
+    ])
 
     // Validate each property node
     const propertyNodes = nodes.filter(node => node.type === 'property')
@@ -67,13 +72,18 @@ export async function validateGraphClientSide(
             }
         }
 
-        // Validate data type semantically (is it the right type for this property?)
+        // Compare the data type against the standard IFC pset template for this
+        // property. This is a RECOMMENDATION, not an error: the IDS spec only
+        // requires a valid datatype, not the template's exact one (issues
+        // #48/#52). Subtype/same-category choices (e.g. IFCPOSITIVELENGTHMEASURE
+        // for a template IFCLENGTHMEASURE) are treated as valid and never
+        // surfaced; only a fundamentally different kind of value is hinted.
         if (data.dataType && data.baseName) {
             const validation = isPropertyDataTypeValid(data.baseName, data.dataType)
             if (!validation.valid && validation.expectedTypes) {
                 issues.push({
-                    severity: 'error',
-                    message: `Property "${data.baseName}" should have data type ${validation.expectedTypes.join(' or ')}, not "${data.dataType}"`,
+                    severity: 'warning',
+                    message: `Property "${data.baseName}" is usually defined as ${validation.expectedTypes.join(' or ')} in standard IFC property sets. You used "${data.dataType}" — a valid IDS datatype, but a different kind of value. Double-check this is intended.`,
                     nodeId: node.id,
                     nodeType: 'property',
                     field: 'dataType',

--- a/lib/ifc-schema.ts
+++ b/lib/ifc-schema.ts
@@ -194,14 +194,38 @@ export function validateProperty(propertySetName: string, propertyName: string):
   return true
 }
 
-// Data type validation cache - populated from generated schema
+// Data type validation cache - populated from generated schema.
+// The list of valid IDS datatypes differs per IFC schema version (e.g.
+// IFCNONNEGATIVELENGTHMEASURE and the date/time types are IFC4+ only), so the
+// cache is rebuilt whenever the requested version changes.
 const validDataTypeCache = new Set<string>()
-let dataTypeCacheBuilt = false
+// Datatype name (UPPERCASE) -> xs: restriction base type (e.g. "xs:double").
+// Used to group datatypes into coarse value categories for compatibility hints.
+const dataTypeBaseTypeCache = new Map<string, string>()
+let simpleTypesCacheVersion: IFCVersion | null = null
+
+async function ensureSimpleTypeCaches(version: IFCVersion): Promise<void> {
+  if (simpleTypesCacheVersion === version && validDataTypeCache.size > 0) return
+  try {
+    const simpleTypes = await loadSimpleTypes(version)
+    if (simpleTypes.length === 0) return // keep any existing cache / legacy fallback
+    validDataTypeCache.clear()
+    dataTypeBaseTypeCache.clear()
+    for (const t of simpleTypes) {
+      const upper = t.name.toUpperCase()
+      validDataTypeCache.add(upper)
+      dataTypeBaseTypeCache.set(upper, (t.baseType || '').trim())
+    }
+    simpleTypesCacheVersion = version
+  } catch (error) {
+    console.warn('Failed to build data type cache:', error)
+  }
+}
 
 export function validateDataType(dataType: string): boolean {
   const upperType = dataType.toUpperCase()
   // Use cache from generated schema if available
-  if (dataTypeCacheBuilt) {
+  if (validDataTypeCache.size > 0) {
     return validDataTypeCache.has(upperType)
   }
   // Fallback to legacy list before cache is built
@@ -209,21 +233,64 @@ export function validateDataType(dataType: string): boolean {
 }
 
 export async function validateDataTypeAsync(dataType: string, version: IFCVersion): Promise<boolean> {
-  await buildDataTypeCache(version)
+  await ensureSimpleTypeCaches(version)
   return validDataTypeCache.has(dataType.toUpperCase())
 }
 
-async function buildDataTypeCache(version: IFCVersion) {
-  if (dataTypeCacheBuilt) return
-  try {
-    const simpleTypes = await loadSimpleTypes(version)
-    for (const t of simpleTypes) {
-      validDataTypeCache.add(t.name.toUpperCase())
-    }
-    dataTypeCacheBuilt = true
-  } catch (error) {
-    console.warn('Failed to build data type cache:', error)
+// Coarse value categories. Two datatypes in the SAME category are considered
+// interchangeable enough that swapping one for the other (e.g. a measure
+// subtype like IFCPOSITIVELENGTHMEASURE for its base IFCLENGTHMEASURE) is never
+// flagged. Per the IDS spec, ANY valid datatype is acceptable for a property —
+// the standard IFC pset template type is only a recommendation — so we only hint
+// when the chosen datatype is a fundamentally different *kind* of value.
+export type DataTypeCategory =
+  | 'numeric'
+  | 'string'
+  | 'boolean'
+  | 'datetime'
+  | 'binary'
+  | 'unknown'
+
+function baseTypeToCategory(base: string): DataTypeCategory {
+  switch (base) {
+    case 'xs:double':
+    case 'xs:integer':
+    case 'xs:decimal':
+      return 'numeric'
+    case 'xs:boolean':
+      return 'boolean'
+    case 'xs:date':
+    case 'xs:dateTime':
+    case 'xs:time':
+    case 'xs:duration':
+      return 'datetime'
+    case 'xs:string':
+    case 'xs:anyURI':
+      return 'string'
+    case '':
+      return 'binary'
+    default:
+      return 'unknown'
   }
+}
+
+export function getDataTypeCategory(dataType: string): DataTypeCategory {
+  const base = dataTypeBaseTypeCache.get(dataType.toUpperCase())
+  if (base === undefined) return 'unknown'
+  return baseTypeToCategory(base)
+}
+
+/**
+ * Whether two IDS datatypes represent the same kind of value. Same exact type,
+ * or same coarse category (e.g. both numeric measures) → compatible. If either
+ * type is unknown to the loaded schema, we err on the side of NOT warning.
+ */
+export function areDataTypesCompatible(a: string, b: string): boolean {
+  if (a.toUpperCase() === b.toUpperCase()) return true
+  const ca = getDataTypeCategory(a)
+  const cb = getDataTypeCategory(b)
+  if (ca === 'unknown' || cb === 'unknown') return true
+  return ca === cb
 }
 
 export function getEntitiesForVersion(version: IFCVersion): string[] {
@@ -274,13 +341,8 @@ export function getPropertiesForPropertySet(propertySetName: string): string[] {
 // Async functions for comprehensive schema access
 export async function getAllSimpleTypes(version: IFCVersion): Promise<IFCDataType[]> {
   const simpleTypes = await loadSimpleTypes(version)
-  // Populate data type validation cache from loaded schema
-  if (!dataTypeCacheBuilt) {
-    for (const t of simpleTypes) {
-      validDataTypeCache.add(t.name.toUpperCase())
-    }
-    dataTypeCacheBuilt = true
-  }
+  // Populate the (version-aware) data type validation + category caches.
+  await ensureSimpleTypeCaches(version)
   return convertSimpleTypes(simpleTypes)
 }
 
@@ -490,6 +552,21 @@ export async function getExpectedDataTypesForPropertyAsync(propertyName: string,
   return getExpectedDataTypesForProperty(propertyName)
 }
 
+/**
+ * Compares a property's chosen datatype against the datatype(s) used for that
+ * property name in the standard IFC property-set templates.
+ *
+ * IMPORTANT (issues #48 / #52): per the IDS specification, a property `dataType`
+ * is OPTIONAL and, when present, only needs to be a valid datatype for the
+ * schema version — it does NOT have to match the IFC pset template's exact type.
+ * So this is a *recommendation* helper, not an IDS rule:
+ *   - exact match, or same value category (e.g. IFCPOSITIVELENGTHMEASURE vs its
+ *     base IFCLENGTHMEASURE) → `valid: true`, no hint.
+ *   - a fundamentally different kind of value (e.g. a text type where the pset
+ *     uses a measure) → `valid: false` + `expectedTypes`, surfaced by callers as
+ *     a non-blocking recommendation.
+ * Custom / unknown properties carry no template opinion and are always valid.
+ */
 export function isPropertyDataTypeValid(propertyName: string, dataType: string): { valid: boolean; expectedTypes?: string[] } {
   const expectedTypes = getExpectedDataTypesForProperty(propertyName)
 
@@ -498,11 +575,17 @@ export function isPropertyDataTypeValid(propertyName: string, dataType: string):
     return { valid: true }
   }
 
-  // Check if the data type matches one of the expected types
-  const isValid = expectedTypes.includes(dataType.toUpperCase())
+  const userUpper = dataType.toUpperCase()
 
-  return {
-    valid: isValid,
-    expectedTypes: isValid ? undefined : expectedTypes
+  // Exact match against any template datatype.
+  if (expectedTypes.some((t) => t.toUpperCase() === userUpper)) {
+    return { valid: true }
   }
+
+  // Subtype / same-category compatibility (measure subtypes, IFCLABEL↔IFCTEXT, …).
+  if (expectedTypes.some((t) => areDataTypesCompatible(userUpper, t))) {
+    return { valid: true }
+  }
+
+  return { valid: false, expectedTypes }
 }

--- a/public/generated/simple-types-ifc2x3.json
+++ b/public/generated/simple-types-ifc2x3.json
@@ -1,243 +1,8 @@
 [
   {
-    "name": "IFCLABEL",
-    "baseType": "xs:string",
-    "description": "Short text string (max 255 characters)"
-  },
-  {
-    "name": "IFCTEXT",
-    "baseType": "xs:string",
-    "description": "Long text string"
-  },
-  {
-    "name": "IFCBOOLEAN",
-    "baseType": "xs:boolean",
-    "description": "True or False value"
-  },
-  {
-    "name": "IFCINTEGER",
-    "baseType": "xs:integer",
-    "description": "Whole number"
-  },
-  {
-    "name": "IFCREAL",
+    "name": "IFCABSORBEDDOSEMEASURE",
     "baseType": "xs:double",
-    "description": "Decimal number"
-  },
-  {
-    "name": "IFCIDENTIFIER",
-    "baseType": "xs:string",
-    "description": "Unique identifier string"
-  },
-  {
-    "name": "IFCLOGICAL",
-    "baseType": "xs:string",
-    "description": "True, False, or Unknown"
-  },
-  {
-    "name": "IFCDATETIME",
-    "baseType": "xs:dateTime",
-    "description": "Date and time value"
-  },
-  {
-    "name": "IFCDATE",
-    "baseType": "xs:date",
-    "description": "Date value"
-  },
-  {
-    "name": "IFCTIME",
-    "baseType": "xs:time",
-    "description": "Time value"
-  },
-  {
-    "name": "IFCDURATION",
-    "baseType": "xs:duration",
-    "description": "Time duration"
-  },
-  {
-    "name": "IFCLENGTHMEASURE",
-    "baseType": "xs:double",
-    "description": "Length measurement"
-  },
-  {
-    "name": "IFCAREAMEASURE",
-    "baseType": "xs:double",
-    "description": "Area measurement"
-  },
-  {
-    "name": "IFCVOLUMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volume measurement"
-  },
-  {
-    "name": "IFCPLANEANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Plane angle measurement"
-  },
-  {
-    "name": "IFCSOLIDANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Solid angle measurement"
-  },
-  {
-    "name": "IFCMASSMEASURE",
-    "baseType": "xs:double",
-    "description": "Mass measurement"
-  },
-  {
-    "name": "IFCPOWERMEASURE",
-    "baseType": "xs:double",
-    "description": "Power measurement"
-  },
-  {
-    "name": "IFCPRESSUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Pressure measurement"
-  },
-  {
-    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal transmittance measurement"
-  },
-  {
-    "name": "IFCENERGYCONVERSIONRATE",
-    "baseType": "xs:double",
-    "description": "Energy conversion rate"
-  },
-  {
-    "name": "IFCTEMPERATUREGRADIENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Temperature gradient measurement"
-  },
-  {
-    "name": "IFCHEATINGVALUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Heating value measurement"
-  },
-  {
-    "name": "IFCTHERMOCONDUCTIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal conductivity measurement"
-  },
-  {
-    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volumetric flow rate measurement"
-  },
-  {
-    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Moisture diffusivity measurement"
-  },
-  {
-    "name": "IFCVAPORPERMEABILITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Vapor permeability measurement"
-  },
-  {
-    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Isothermal moisture capacity measurement"
-  },
-  {
-    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Specific heat capacity measurement"
-  },
-  {
-    "name": "IFCMONETARYMEASURE",
-    "baseType": "xs:double",
-    "description": "Monetary measurement"
-  },
-  {
-    "name": "IFCCOUNTMEASURE",
-    "baseType": "xs:integer",
-    "description": "Count measurement"
-  },
-  {
-    "name": "IFCTIMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Time measurement"
-  },
-  {
-    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermodynamic temperature measurement"
-  },
-  {
-    "name": "IFCPHMEASURE",
-    "baseType": "xs:double",
-    "description": "pH measurement"
-  },
-  {
-    "name": "IFCFREQUENCYMEASURE",
-    "baseType": "xs:double",
-    "description": "Frequency measurement"
-  },
-  {
-    "name": "IFCILLUMINANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Illuminance measurement"
-  },
-  {
-    "name": "IFCLUMINOUSFLUXMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous flux measurement"
-  },
-  {
-    "name": "IFCLUMINOUSINTENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous intensity measurement"
-  },
-  {
-    "name": "IFCELECTRICVOLTAGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric voltage measurement"
-  },
-  {
-    "name": "IFCELECTRICCURRENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric current measurement"
-  },
-  {
-    "name": "IFCELECTRICCHARGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric charge measurement"
-  },
-  {
-    "name": "IFCELECTRICRESISTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric resistance measurement"
-  },
-  {
-    "name": "IFCELECTRICCONDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric conductance measurement"
-  },
-  {
-    "name": "IFCELECTRICCAPACITANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric capacitance measurement"
-  },
-  {
-    "name": "IFCINDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Inductance measurement"
-  },
-  {
-    "name": "IFCFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Force measurement"
-  },
-  {
-    "name": "IFCMOMENTOFINERTIAMEASURE",
-    "baseType": "xs:double",
-    "description": "Moment of inertia measurement"
-  },
-  {
-    "name": "IFCTORQUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Torque measurement"
+    "description": "Measure value (decimal)"
   },
   {
     "name": "IFCACCELERATIONMEASURE",
@@ -245,9 +10,59 @@
     "description": "Acceleration measurement"
   },
   {
-    "name": "IFCLINEARVELOCITYMEASURE",
+    "name": "IFCACTIONSOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTUATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCADDRESSTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTOAIRHEATRECOVERYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALARMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAMOUNTOFSUBSTANCEMEASURE",
     "baseType": "xs:double",
-    "description": "Linear velocity measurement"
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCANALYSISMODELTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCANALYSISTHEORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCANGULARVELOCITYMEASURE",
@@ -255,44 +70,559 @@
     "description": "Angular velocity measurement"
   },
   {
+    "name": "IFCAREAMEASURE",
+    "baseType": "xs:double",
+    "description": "Area measurement"
+  },
+  {
+    "name": "IFCARITHMETICOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCASSEMBLYPLACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBENCHMARKENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBOILERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBOOLEAN",
+    "baseType": "xs:boolean",
+    "description": "True or False value"
+  },
+  {
+    "name": "IFCBOXALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPROXYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHANGEACTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHILLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOLUMNTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPRESSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONDENSERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRAINTENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONTEXTDEPENDENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCONTROLLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLEDBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLINGTOWERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOUNTMEASURE",
+    "baseType": "xs:integer",
+    "description": "Count measurement"
+  },
+  {
+    "name": "IFCCOVERINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURRENCYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURTAINWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURVATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCDAMPERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATAORIGINENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDAYINMONTHNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDAYLIGHTSAVINGHOUR",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDERIVEDUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDESCRIPTIVEMEASURE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCDIMENSIONCOUNT",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDIRECTIONSENSEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONCHAMBERELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTCONFIDENTIALITYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTSTATUSENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORSTYLECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORSTYLEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOSEEQUIVALENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCDUCTFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSILENCERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDYNAMICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCELECTRICAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICCAPACITANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric capacitance measurement"
+  },
+  {
+    "name": "IFCELECTRICCHARGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric charge measurement"
+  },
+  {
+    "name": "IFCELECTRICCONDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric conductance measurement"
+  },
+  {
+    "name": "IFCELECTRICCURRENTENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICCURRENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric current measurement"
+  },
+  {
+    "name": "IFCELECTRICDISTRIBUTIONPOINTFUNCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICFLOWSTORAGEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICGENERATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICHEATERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICMOTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric resistance measurement"
+  },
+  {
+    "name": "IFCELECTRICTIMECONTROLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICVOLTAGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric voltage measurement"
+  },
+  {
+    "name": "IFCELEMENTASSEMBLYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELEMENTCOMPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCENERGYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCENERGYSEQUENCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCENVIRONMENTALIMPACTCATEGORYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATIVECOOLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFILTERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFIRESUPPRESSIONTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWINSTRUMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWMETERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFONTSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTVARIANT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTWEIGHT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFOOTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Force measurement"
+  },
+  {
+    "name": "IFCFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Frequency measurement"
+  },
+  {
+    "name": "IFCGASTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOMETRICPROJECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGLOBALLYUNIQUEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCGLOBALORLOCALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATEXCHANGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCHEATINGVALUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Heating value measurement"
+  },
+  {
+    "name": "IFCHOURINDAY",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCHUMIDIFIERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIDENTIFIER",
+    "baseType": "xs:string",
+    "description": "Unique identifier string"
+  },
+  {
+    "name": "IFCILLUMINANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Illuminance measurement"
+  },
+  {
+    "name": "IFCINDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Inductance measurement"
+  },
+  {
+    "name": "IFCINTEGER",
+    "baseType": "xs:integer",
+    "description": "Whole number"
+  },
+  {
+    "name": "IFCINTEGERCOUNTRATEMEASURE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCINTERNALOREXTERNALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINVENTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIONCONCENTRATIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Isothermal moisture capacity measurement"
+  },
+  {
+    "name": "IFCJUNCTIONBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCKINEMATICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLABEL",
+    "baseType": "xs:string",
+    "description": "Short text string (max 255 characters)"
+  },
+  {
+    "name": "IFCLAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLAYERSETDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Length measurement"
+  },
+  {
+    "name": "IFCLIGHTDISTRIBUTIONCURVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTEMISSIONSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTFIXTURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
     "name": "IFCLINEARFORCEMEASURE",
     "baseType": "xs:double",
     "description": "Linear force measurement"
-  },
-  {
-    "name": "IFCPLANARFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Planar force measurement"
-  },
-  {
-    "name": "IFCLINEARSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear stiffness measurement"
-  },
-  {
-    "name": "IFCROTATIONALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Rotational stiffness measurement"
-  },
-  {
-    "name": "IFCWARPINGMOMENTALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Warping momental stiffness measurement"
-  },
-  {
-    "name": "IFCMODULUSOFELASTICITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Modulus of elasticity measurement"
-  },
-  {
-    "name": "IFCSHEARMODULUSMEASURE",
-    "baseType": "xs:double",
-    "description": "Shear modulus measurement"
-  },
-  {
-    "name": "IFCLINEARDENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear density measurement"
   },
   {
     "name": "IFCLINEARMOMENTMEASURE",
@@ -300,14 +630,384 @@
     "description": "Linear moment measurement"
   },
   {
-    "name": "IFCPLANARMOMENTMEASURE",
+    "name": "IFCLINEARSTIFFNESSMEASURE",
     "baseType": "xs:double",
-    "description": "Planar moment measurement"
+    "description": "Linear stiffness measurement"
   },
   {
-    "name": "IFCSECTIONMODULUSMEASURE",
+    "name": "IFCLINEARVELOCITYMEASURE",
     "baseType": "xs:double",
-    "description": "Section modulus measurement"
+    "description": "Linear velocity measurement"
+  },
+  {
+    "name": "IFCLOADGROUPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLOGICAL",
+    "baseType": "xs:string",
+    "description": "True, False, or Unknown"
+  },
+  {
+    "name": "IFCLOGICALOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLUMINOUSFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous flux measurement"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYDISTRIBUTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous intensity measurement"
+  },
+  {
+    "name": "IFCMAGNETICFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMAGNETICFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Mass measurement"
+  },
+  {
+    "name": "IFCMASSPERLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMINUTEINHOUR",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCMODULUSOFELASTICITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Modulus of elasticity measurement"
+  },
+  {
+    "name": "IFCMODULUSOFLINEARSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFROTATIONALSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Moisture diffusivity measurement"
+  },
+  {
+    "name": "IFCMOLECULARWEIGHTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOMENTOFINERTIAMEASURE",
+    "baseType": "xs:double",
+    "description": "Moment of inertia measurement"
+  },
+  {
+    "name": "IFCMONETARYMEASURE",
+    "baseType": "xs:double",
+    "description": "Monetary measurement"
+  },
+  {
+    "name": "IFCMONTHINYEARNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCMOTORCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCNORMALISEDRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNULLSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCNUMERICMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCOBJECTIVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOBJECTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOCCUPANTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOUTLETTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPARAMETERVALUE",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCPERMEABLECOVERINGOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPHMEASURE",
+    "baseType": "xs:double",
+    "description": "pH measurement"
+  },
+  {
+    "name": "IFCPHYSICALORVIRTUALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPLANARFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Planar force measurement"
+  },
+  {
+    "name": "IFCPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Plane angle measurement"
+  },
+  {
+    "name": "IFCPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPOSITIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVEPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVERATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Power measurement"
+  },
+  {
+    "name": "IFCPRESENTABLETEXT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Pressure measurement"
+  },
+  {
+    "name": "IFCPROCEDURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROFILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTEDORTRUELENGTHENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTORDERRECORDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTORDERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROPERTYSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPUMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRADIOACTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCRAILINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCREAL",
+    "baseType": "xs:double",
+    "description": "Decimal number"
+  },
+  {
+    "name": "IFCREFLECTANCEMETHODENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARSURFACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRESOURCECONSUMPTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRIBPLATEDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROOFTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROTATIONALFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALSTIFFNESSMEASURE",
+    "baseType": "xs:double",
+    "description": "Rotational stiffness measurement"
+  },
+  {
+    "name": "IFCSANITARYTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSECONDINMINUTE",
+    "baseType": "xs:double",
+    "description": "Decimal value"
   },
   {
     "name": "IFCSECTIONALAREAINTEGRALMEASURE",
@@ -315,8 +1015,333 @@
     "description": "Sectional area integral measurement"
   },
   {
-    "name": "IFCWARPING",
+    "name": "IFCSECTIONMODULUSMEASURE",
     "baseType": "xs:double",
-    "description": "Warping measurement"
+    "description": "Section modulus measurement"
+  },
+  {
+    "name": "IFCSECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSENSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSEQUENCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSERVICELIFEFACTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSERVICELIFETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHEARMODULUSMEASURE",
+    "baseType": "xs:double",
+    "description": "Shear modulus measurement"
+  },
+  {
+    "name": "IFCSLABTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLIDANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Solid angle measurement"
+  },
+  {
+    "name": "IFCSOUNDPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDSCALEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPACEHEATERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPACETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Specific heat capacity measurement"
+  },
+  {
+    "name": "IFCSPECULAREXPONENT",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSPECULARROUGHNESS",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSTACKTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTATEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSURFACETEXTUREENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSWITCHINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTANKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEMPERATUREGRADIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Temperature gradient measurement"
+  },
+  {
+    "name": "IFCTENDONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEXT",
+    "baseType": "xs:string",
+    "description": "Long text string"
+  },
+  {
+    "name": "IFCTEXTALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTDECORATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTFONTNAME",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTTRANSFORMATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTHERMALADMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALCONDUCTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALEXPANSIONCOEFFICIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALLOADSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTHERMALLOADTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTHERMALRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermal transmittance measurement"
+  },
+  {
+    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermodynamic temperature measurement"
+  },
+  {
+    "name": "IFCTIMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Time measurement"
+  },
+  {
+    "name": "IFCTIMESERIESDATATYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTIMESERIESSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTIMESTAMP",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCTORQUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Torque measurement"
+  },
+  {
+    "name": "IFCTRANSFORMERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTRANSPORTELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTUBEBUNDLETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYEQUIPMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVALVETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVAPORPERMEABILITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Vapor permeability measurement"
+  },
+  {
+    "name": "IFCVIBRATIONISOLATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOLUMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volume measurement"
+  },
+  {
+    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volumetric flow rate measurement"
+  },
+  {
+    "name": "IFCWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWARPINGCONSTANTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWARPINGMOMENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWASTETERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWSTYLECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWSTYLEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKCONTROLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCYEARNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
   }
 ]

--- a/public/generated/simple-types-ifc4.json
+++ b/public/generated/simple-types-ifc4.json
@@ -1,243 +1,8 @@
 [
   {
-    "name": "IFCLABEL",
-    "baseType": "xs:string",
-    "description": "Short text string (max 255 characters)"
-  },
-  {
-    "name": "IFCTEXT",
-    "baseType": "xs:string",
-    "description": "Long text string"
-  },
-  {
-    "name": "IFCBOOLEAN",
-    "baseType": "xs:boolean",
-    "description": "True or False value"
-  },
-  {
-    "name": "IFCINTEGER",
-    "baseType": "xs:integer",
-    "description": "Whole number"
-  },
-  {
-    "name": "IFCREAL",
+    "name": "IFCABSORBEDDOSEMEASURE",
     "baseType": "xs:double",
-    "description": "Decimal number"
-  },
-  {
-    "name": "IFCIDENTIFIER",
-    "baseType": "xs:string",
-    "description": "Unique identifier string"
-  },
-  {
-    "name": "IFCLOGICAL",
-    "baseType": "xs:string",
-    "description": "True, False, or Unknown"
-  },
-  {
-    "name": "IFCDATETIME",
-    "baseType": "xs:dateTime",
-    "description": "Date and time value"
-  },
-  {
-    "name": "IFCDATE",
-    "baseType": "xs:date",
-    "description": "Date value"
-  },
-  {
-    "name": "IFCTIME",
-    "baseType": "xs:time",
-    "description": "Time value"
-  },
-  {
-    "name": "IFCDURATION",
-    "baseType": "xs:duration",
-    "description": "Time duration"
-  },
-  {
-    "name": "IFCLENGTHMEASURE",
-    "baseType": "xs:double",
-    "description": "Length measurement"
-  },
-  {
-    "name": "IFCAREAMEASURE",
-    "baseType": "xs:double",
-    "description": "Area measurement"
-  },
-  {
-    "name": "IFCVOLUMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volume measurement"
-  },
-  {
-    "name": "IFCPLANEANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Plane angle measurement"
-  },
-  {
-    "name": "IFCSOLIDANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Solid angle measurement"
-  },
-  {
-    "name": "IFCMASSMEASURE",
-    "baseType": "xs:double",
-    "description": "Mass measurement"
-  },
-  {
-    "name": "IFCPOWERMEASURE",
-    "baseType": "xs:double",
-    "description": "Power measurement"
-  },
-  {
-    "name": "IFCPRESSUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Pressure measurement"
-  },
-  {
-    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal transmittance measurement"
-  },
-  {
-    "name": "IFCENERGYCONVERSIONRATE",
-    "baseType": "xs:double",
-    "description": "Energy conversion rate"
-  },
-  {
-    "name": "IFCTEMPERATUREGRADIENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Temperature gradient measurement"
-  },
-  {
-    "name": "IFCHEATINGVALUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Heating value measurement"
-  },
-  {
-    "name": "IFCTHERMOCONDUCTIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal conductivity measurement"
-  },
-  {
-    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volumetric flow rate measurement"
-  },
-  {
-    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Moisture diffusivity measurement"
-  },
-  {
-    "name": "IFCVAPORPERMEABILITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Vapor permeability measurement"
-  },
-  {
-    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Isothermal moisture capacity measurement"
-  },
-  {
-    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Specific heat capacity measurement"
-  },
-  {
-    "name": "IFCMONETARYMEASURE",
-    "baseType": "xs:double",
-    "description": "Monetary measurement"
-  },
-  {
-    "name": "IFCCOUNTMEASURE",
-    "baseType": "xs:integer",
-    "description": "Count measurement"
-  },
-  {
-    "name": "IFCTIMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Time measurement"
-  },
-  {
-    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermodynamic temperature measurement"
-  },
-  {
-    "name": "IFCPHMEASURE",
-    "baseType": "xs:double",
-    "description": "pH measurement"
-  },
-  {
-    "name": "IFCFREQUENCYMEASURE",
-    "baseType": "xs:double",
-    "description": "Frequency measurement"
-  },
-  {
-    "name": "IFCILLUMINANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Illuminance measurement"
-  },
-  {
-    "name": "IFCLUMINOUSFLUXMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous flux measurement"
-  },
-  {
-    "name": "IFCLUMINOUSINTENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous intensity measurement"
-  },
-  {
-    "name": "IFCELECTRICVOLTAGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric voltage measurement"
-  },
-  {
-    "name": "IFCELECTRICCURRENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric current measurement"
-  },
-  {
-    "name": "IFCELECTRICCHARGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric charge measurement"
-  },
-  {
-    "name": "IFCELECTRICRESISTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric resistance measurement"
-  },
-  {
-    "name": "IFCELECTRICCONDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric conductance measurement"
-  },
-  {
-    "name": "IFCELECTRICCAPACITANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric capacitance measurement"
-  },
-  {
-    "name": "IFCINDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Inductance measurement"
-  },
-  {
-    "name": "IFCFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Force measurement"
-  },
-  {
-    "name": "IFCMOMENTOFINERTIAMEASURE",
-    "baseType": "xs:double",
-    "description": "Moment of inertia measurement"
-  },
-  {
-    "name": "IFCTORQUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Torque measurement"
+    "description": "Measure value (decimal)"
   },
   {
     "name": "IFCACCELERATIONMEASURE",
@@ -245,9 +10,64 @@
     "description": "Acceleration measurement"
   },
   {
-    "name": "IFCLINEARVELOCITYMEASURE",
+    "name": "IFCACTIONREQUESTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONSOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTUATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCADDRESSTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTOAIRHEATRECOVERYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALARMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAMOUNTOFSUBSTANCEMEASURE",
     "baseType": "xs:double",
-    "description": "Linear velocity measurement"
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCANALYSISMODELTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCANALYSISTHEORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCANGULARVELOCITYMEASURE",
@@ -255,44 +75,704 @@
     "description": "Angular velocity measurement"
   },
   {
+    "name": "IFCAREADENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCAREAMEASURE",
+    "baseType": "xs:double",
+    "description": "Area measurement"
+  },
+  {
+    "name": "IFCARITHMETICOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCASSEMBLYPLACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAUDIOVISUALAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBENCHMARKENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBINARY",
+    "baseType": "",
+    "description": "Binary value"
+  },
+  {
+    "name": "IFCBOILERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBOOLEAN",
+    "baseType": "xs:boolean",
+    "description": "True or False value"
+  },
+  {
+    "name": "IFCBOXALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPROXYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGSYSTEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBURNERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCARDINALPOINTREFERENCE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCCHANGEACTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHILLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHIMNEYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOLUMNTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMMUNICATIONSAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPLEXPROPERTYTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPRESSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONDENSERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRAINTENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONEQUIPMENTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONMATERIALRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONPRODUCTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONTEXTDEPENDENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCONTROLLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLEDBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLINGTOWERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTITEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOUNTMEASURE",
+    "baseType": "xs:integer",
+    "description": "Count measurement"
+  },
+  {
+    "name": "IFCCOVERINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCREWRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURTAINWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURVATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCURVEINTERPOLATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDAMPERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATAORIGINENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATE",
+    "baseType": "xs:date",
+    "description": "Date value"
+  },
+  {
+    "name": "IFCDATETIME",
+    "baseType": "xs:dateTime",
+    "description": "Date and time value"
+  },
+  {
+    "name": "IFCDAYINMONTHNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDAYINWEEKNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDERIVEDUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDESCRIPTIVEMEASURE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCDIMENSIONCOUNT",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDIRECTIONSENSEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISCRETEACCESSORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONCHAMBERELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONPORTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONSYSTEMENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTCONFIDENTIALITYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTSTATUSENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORSTYLECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORSTYLEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORTYPEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOSEEQUIVALENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCDUCTFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSILENCERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDURATION",
+    "baseType": "xs:duration",
+    "description": "Time duration"
+  },
+  {
+    "name": "IFCDYNAMICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCELECTRICAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICCAPACITANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric capacitance measurement"
+  },
+  {
+    "name": "IFCELECTRICCHARGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric charge measurement"
+  },
+  {
+    "name": "IFCELECTRICCONDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric conductance measurement"
+  },
+  {
+    "name": "IFCELECTRICCURRENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric current measurement"
+  },
+  {
+    "name": "IFCELECTRICDISTRIBUTIONBOARDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICFLOWSTORAGEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICGENERATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICMOTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric resistance measurement"
+  },
+  {
+    "name": "IFCELECTRICTIMECONTROLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICVOLTAGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric voltage measurement"
+  },
+  {
+    "name": "IFCELEMENTASSEMBLYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELEMENTCOMPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCENERGYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCENGINETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATIVECOOLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVENTTRIGGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEXTERNALSPATIALELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFASTENERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFILTERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFIRESUPPRESSIONTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWINSTRUMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWMETERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFONTSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTVARIANT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTWEIGHT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFOOTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Force measurement"
+  },
+  {
+    "name": "IFCFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Frequency measurement"
+  },
+  {
+    "name": "IFCFURNITURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOGRAPHICELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOMETRICPROJECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGLOBALLYUNIQUEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCGLOBALORLOCALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGRIDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATEXCHANGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCHEATINGVALUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Heating value measurement"
+  },
+  {
+    "name": "IFCHUMIDIFIERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIDENTIFIER",
+    "baseType": "xs:string",
+    "description": "Unique identifier string"
+  },
+  {
+    "name": "IFCILLUMINANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Illuminance measurement"
+  },
+  {
+    "name": "IFCINDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Inductance measurement"
+  },
+  {
+    "name": "IFCINTEGER",
+    "baseType": "xs:integer",
+    "description": "Whole number"
+  },
+  {
+    "name": "IFCINTEGERCOUNTRATEMEASURE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCINTERCEPTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINTERNALOREXTERNALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINVENTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIONCONCENTRATIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Isothermal moisture capacity measurement"
+  },
+  {
+    "name": "IFCJUNCTIONBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCKINEMATICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLABEL",
+    "baseType": "xs:string",
+    "description": "Short text string (max 255 characters)"
+  },
+  {
+    "name": "IFCLABORRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLANGUAGEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCLAYERSETDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Length measurement"
+  },
+  {
+    "name": "IFCLIGHTDISTRIBUTIONCURVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTEMISSIONSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTFIXTURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
     "name": "IFCLINEARFORCEMEASURE",
     "baseType": "xs:double",
     "description": "Linear force measurement"
-  },
-  {
-    "name": "IFCPLANARFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Planar force measurement"
-  },
-  {
-    "name": "IFCLINEARSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear stiffness measurement"
-  },
-  {
-    "name": "IFCROTATIONALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Rotational stiffness measurement"
-  },
-  {
-    "name": "IFCWARPINGMOMENTALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Warping momental stiffness measurement"
-  },
-  {
-    "name": "IFCMODULUSOFELASTICITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Modulus of elasticity measurement"
-  },
-  {
-    "name": "IFCSHEARMODULUSMEASURE",
-    "baseType": "xs:double",
-    "description": "Shear modulus measurement"
-  },
-  {
-    "name": "IFCLINEARDENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear density measurement"
   },
   {
     "name": "IFCLINEARMOMENTMEASURE",
@@ -300,14 +780,424 @@
     "description": "Linear moment measurement"
   },
   {
-    "name": "IFCPLANARMOMENTMEASURE",
+    "name": "IFCLINEARSTIFFNESSMEASURE",
     "baseType": "xs:double",
-    "description": "Planar moment measurement"
+    "description": "Linear stiffness measurement"
   },
   {
-    "name": "IFCSECTIONMODULUSMEASURE",
+    "name": "IFCLINEARVELOCITYMEASURE",
     "baseType": "xs:double",
-    "description": "Section modulus measurement"
+    "description": "Linear velocity measurement"
+  },
+  {
+    "name": "IFCLOADGROUPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLOGICAL",
+    "baseType": "xs:string",
+    "description": "True, False, or Unknown"
+  },
+  {
+    "name": "IFCLOGICALOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLUMINOUSFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous flux measurement"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYDISTRIBUTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous intensity measurement"
+  },
+  {
+    "name": "IFCMAGNETICFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMAGNETICFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Mass measurement"
+  },
+  {
+    "name": "IFCMASSPERLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMECHANICALFASTENERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMEDICALDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMODULUSOFELASTICITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Modulus of elasticity measurement"
+  },
+  {
+    "name": "IFCMODULUSOFLINEARSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFROTATIONALSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Moisture diffusivity measurement"
+  },
+  {
+    "name": "IFCMOLECULARWEIGHTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOMENTOFINERTIAMEASURE",
+    "baseType": "xs:double",
+    "description": "Moment of inertia measurement"
+  },
+  {
+    "name": "IFCMONETARYMEASURE",
+    "baseType": "xs:double",
+    "description": "Monetary measurement"
+  },
+  {
+    "name": "IFCMONTHINYEARNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCMOTORCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCNONNEGATIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNORMALISEDRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNULLSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCNUMERICMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCOBJECTIVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOBJECTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOCCUPANTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOPENINGELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOUTLETTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPARAMETERVALUE",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCPERFORMANCEHISTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERMEABLECOVERINGOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERMITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPHMEASURE",
+    "baseType": "xs:double",
+    "description": "pH measurement"
+  },
+  {
+    "name": "IFCPHYSICALORVIRTUALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPLANARFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Planar force measurement"
+  },
+  {
+    "name": "IFCPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Plane angle measurement"
+  },
+  {
+    "name": "IFCPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPOSITIVEINTEGER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCPOSITIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVEPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVERATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Power measurement"
+  },
+  {
+    "name": "IFCPRESENTABLETEXT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Pressure measurement"
+  },
+  {
+    "name": "IFCPROCEDURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROFILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTEDORTRUELENGTHENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTIONELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTORDERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROPERTYSETTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETRIPPINGUNITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPUMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRADIOACTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCRAILINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCREAL",
+    "baseType": "xs:double",
+    "description": "Decimal number"
+  },
+  {
+    "name": "IFCRECURRENCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREFERENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREFLECTANCEMETHODENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARSURFACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGMESHTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROOFTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROTATIONALFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALSTIFFNESSMEASURE",
+    "baseType": "xs:double",
+    "description": "Rotational stiffness measurement"
+  },
+  {
+    "name": "IFCSANITARYTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCSECTIONALAREAINTEGRALMEASURE",
@@ -315,8 +1205,413 @@
     "description": "Sectional area integral measurement"
   },
   {
-    "name": "IFCWARPING",
+    "name": "IFCSECTIONMODULUSMEASURE",
     "baseType": "xs:double",
-    "description": "Warping measurement"
+    "description": "Section modulus measurement"
+  },
+  {
+    "name": "IFCSECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSENSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSEQUENCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHADINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHEARMODULUSMEASURE",
+    "baseType": "xs:double",
+    "description": "Shear modulus measurement"
+  },
+  {
+    "name": "IFCSIMPLEPROPERTYTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSLABTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLARDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLIDANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Solid angle measurement"
+  },
+  {
+    "name": "IFCSOUNDPOWERLEVELMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSURELEVELMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSPACEHEATERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPACETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPATIALZONETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Specific heat capacity measurement"
+  },
+  {
+    "name": "IFCSPECULAREXPONENT",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSPECULARROUGHNESS",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSTACKTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTATEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRIPPEDOPTIONAL",
+    "baseType": "xs:boolean",
+    "description": "Boolean value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVEACTIVITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVEMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACEACTIVITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACEMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSUBCONTRACTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSURFACEFEATURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSWITCHINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSYSTEMFURNITUREELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTANKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTASKDURATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTASKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEMPERATUREGRADIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Temperature gradient measurement"
+  },
+  {
+    "name": "IFCTEMPERATURERATEOFCHANGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTENDONANCHORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTENDONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEXT",
+    "baseType": "xs:string",
+    "description": "Long text string"
+  },
+  {
+    "name": "IFCTEXTALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTDECORATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTFONTNAME",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTTRANSFORMATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTHERMALADMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALCONDUCTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALEXPANSIONCOEFFICIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermal transmittance measurement"
+  },
+  {
+    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermodynamic temperature measurement"
+  },
+  {
+    "name": "IFCTIME",
+    "baseType": "xs:time",
+    "description": "Time value"
+  },
+  {
+    "name": "IFCTIMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Time measurement"
+  },
+  {
+    "name": "IFCTIMESERIESDATATYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTIMESTAMP",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCTORQUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Torque measurement"
+  },
+  {
+    "name": "IFCTRANSFORMERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTRANSPORTELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTUBEBUNDLETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYCONTROLELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYEQUIPMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCURIREFERENCE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCVALVETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVAPORPERMEABILITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Vapor permeability measurement"
+  },
+  {
+    "name": "IFCVIBRATIONISOLATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOIDINGFEATURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOLUMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volume measurement"
+  },
+  {
+    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volumetric flow rate measurement"
+  },
+  {
+    "name": "IFCWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWARPINGCONSTANTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWARPINGMOMENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWASTETERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWSTYLECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWSTYLEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWTYPEPARTITIONINGENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKCALENDARTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKPLANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   }
 ]

--- a/public/generated/simple-types-ifc4x3_add2.json
+++ b/public/generated/simple-types-ifc4x3_add2.json
@@ -1,243 +1,8 @@
 [
   {
-    "name": "IFCLABEL",
-    "baseType": "xs:string",
-    "description": "Short text string (max 255 characters)"
-  },
-  {
-    "name": "IFCTEXT",
-    "baseType": "xs:string",
-    "description": "Long text string"
-  },
-  {
-    "name": "IFCBOOLEAN",
-    "baseType": "xs:boolean",
-    "description": "True or False value"
-  },
-  {
-    "name": "IFCINTEGER",
-    "baseType": "xs:integer",
-    "description": "Whole number"
-  },
-  {
-    "name": "IFCREAL",
+    "name": "IFCABSORBEDDOSEMEASURE",
     "baseType": "xs:double",
-    "description": "Decimal number"
-  },
-  {
-    "name": "IFCIDENTIFIER",
-    "baseType": "xs:string",
-    "description": "Unique identifier string"
-  },
-  {
-    "name": "IFCLOGICAL",
-    "baseType": "xs:string",
-    "description": "True, False, or Unknown"
-  },
-  {
-    "name": "IFCDATETIME",
-    "baseType": "xs:dateTime",
-    "description": "Date and time value"
-  },
-  {
-    "name": "IFCDATE",
-    "baseType": "xs:date",
-    "description": "Date value"
-  },
-  {
-    "name": "IFCTIME",
-    "baseType": "xs:time",
-    "description": "Time value"
-  },
-  {
-    "name": "IFCDURATION",
-    "baseType": "xs:duration",
-    "description": "Time duration"
-  },
-  {
-    "name": "IFCLENGTHMEASURE",
-    "baseType": "xs:double",
-    "description": "Length measurement"
-  },
-  {
-    "name": "IFCAREAMEASURE",
-    "baseType": "xs:double",
-    "description": "Area measurement"
-  },
-  {
-    "name": "IFCVOLUMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volume measurement"
-  },
-  {
-    "name": "IFCPLANEANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Plane angle measurement"
-  },
-  {
-    "name": "IFCSOLIDANGLEMEASURE",
-    "baseType": "xs:double",
-    "description": "Solid angle measurement"
-  },
-  {
-    "name": "IFCMASSMEASURE",
-    "baseType": "xs:double",
-    "description": "Mass measurement"
-  },
-  {
-    "name": "IFCPOWERMEASURE",
-    "baseType": "xs:double",
-    "description": "Power measurement"
-  },
-  {
-    "name": "IFCPRESSUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Pressure measurement"
-  },
-  {
-    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal transmittance measurement"
-  },
-  {
-    "name": "IFCENERGYCONVERSIONRATE",
-    "baseType": "xs:double",
-    "description": "Energy conversion rate"
-  },
-  {
-    "name": "IFCTEMPERATUREGRADIENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Temperature gradient measurement"
-  },
-  {
-    "name": "IFCHEATINGVALUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Heating value measurement"
-  },
-  {
-    "name": "IFCTHERMOCONDUCTIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermal conductivity measurement"
-  },
-  {
-    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
-    "baseType": "xs:double",
-    "description": "Volumetric flow rate measurement"
-  },
-  {
-    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Moisture diffusivity measurement"
-  },
-  {
-    "name": "IFCVAPORPERMEABILITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Vapor permeability measurement"
-  },
-  {
-    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Isothermal moisture capacity measurement"
-  },
-  {
-    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Specific heat capacity measurement"
-  },
-  {
-    "name": "IFCMONETARYMEASURE",
-    "baseType": "xs:double",
-    "description": "Monetary measurement"
-  },
-  {
-    "name": "IFCCOUNTMEASURE",
-    "baseType": "xs:integer",
-    "description": "Count measurement"
-  },
-  {
-    "name": "IFCTIMEMEASURE",
-    "baseType": "xs:double",
-    "description": "Time measurement"
-  },
-  {
-    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
-    "baseType": "xs:double",
-    "description": "Thermodynamic temperature measurement"
-  },
-  {
-    "name": "IFCPHMEASURE",
-    "baseType": "xs:double",
-    "description": "pH measurement"
-  },
-  {
-    "name": "IFCFREQUENCYMEASURE",
-    "baseType": "xs:double",
-    "description": "Frequency measurement"
-  },
-  {
-    "name": "IFCILLUMINANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Illuminance measurement"
-  },
-  {
-    "name": "IFCLUMINOUSFLUXMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous flux measurement"
-  },
-  {
-    "name": "IFCLUMINOUSINTENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Luminous intensity measurement"
-  },
-  {
-    "name": "IFCELECTRICVOLTAGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric voltage measurement"
-  },
-  {
-    "name": "IFCELECTRICCURRENTMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric current measurement"
-  },
-  {
-    "name": "IFCELECTRICCHARGEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric charge measurement"
-  },
-  {
-    "name": "IFCELECTRICRESISTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric resistance measurement"
-  },
-  {
-    "name": "IFCELECTRICCONDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric conductance measurement"
-  },
-  {
-    "name": "IFCELECTRICCAPACITANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Electric capacitance measurement"
-  },
-  {
-    "name": "IFCINDUCTANCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Inductance measurement"
-  },
-  {
-    "name": "IFCFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Force measurement"
-  },
-  {
-    "name": "IFCMOMENTOFINERTIAMEASURE",
-    "baseType": "xs:double",
-    "description": "Moment of inertia measurement"
-  },
-  {
-    "name": "IFCTORQUEMEASURE",
-    "baseType": "xs:double",
-    "description": "Torque measurement"
+    "description": "Measure value (decimal)"
   },
   {
     "name": "IFCACCELERATIONMEASURE",
@@ -245,9 +10,84 @@
     "description": "Acceleration measurement"
   },
   {
-    "name": "IFCLINEARVELOCITYMEASURE",
+    "name": "IFCACTIONREQUESTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONSOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCACTUATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCADDRESSTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAIRTOAIRHEATRECOVERYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALARMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALIGNMENTCANTSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALIGNMENTHORIZONTALSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALIGNMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCALIGNMENTVERTICALSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAMOUNTOFSUBSTANCEMEASURE",
     "baseType": "xs:double",
-    "description": "Linear velocity measurement"
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCANALYSISMODELTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCANALYSISTHEORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCANGULARVELOCITYMEASURE",
@@ -255,44 +95,779 @@
     "description": "Angular velocity measurement"
   },
   {
+    "name": "IFCANNOTATIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAREADENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCAREAMEASURE",
+    "baseType": "xs:double",
+    "description": "Area measurement"
+  },
+  {
+    "name": "IFCARITHMETICOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCASSEMBLYPLACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCAUDIOVISUALAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBEARINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBENCHMARKENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBINARY",
+    "baseType": "",
+    "description": "Binary value"
+  },
+  {
+    "name": "IFCBOILERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBOOLEAN",
+    "baseType": "xs:boolean",
+    "description": "True or False value"
+  },
+  {
+    "name": "IFCBOXALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCBRIDGEPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBRIDGETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGELEMENTPROXYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILDINGSYSTEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBUILTSYSTEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCBURNERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLECARRIERSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCABLESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCAISSONFOUNDATIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCARDINALPOINTREFERENCE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCCHANGEACTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHILLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCHIMNEYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOLUMNTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMMUNICATIONSAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPLEXPROPERTYTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOMPRESSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONDENSERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRAINTENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONEQUIPMENTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONMATERIALRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONSTRUCTIONPRODUCTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONTEXTDEPENDENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCONTROLLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCONVEYORSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLEDBEAMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOOLINGTOWERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTITEMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOUNTMEASURE",
+    "baseType": "xs:integer",
+    "description": "Count measurement"
+  },
+  {
+    "name": "IFCCOURSETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOVERINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCREWRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURTAINWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCURVATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCCURVEINTERPOLATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDAMPERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATAORIGINENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDATE",
+    "baseType": "xs:date",
+    "description": "Date value"
+  },
+  {
+    "name": "IFCDATETIME",
+    "baseType": "xs:dateTime",
+    "description": "Date and time value"
+  },
+  {
+    "name": "IFCDAYINMONTHNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDAYINWEEKNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDERIVEDUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDESCRIPTIVEMEASURE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCDIMENSIONCOUNT",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCDIRECTIONSENSEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISCRETEACCESSORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONBOARDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONCHAMBERELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONPORTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDISTRIBUTIONSYSTEMENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTCONFIDENTIALITYENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTSTATUSENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOORTYPEOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOSEEQUIVALENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCDUCTFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDUCTSILENCERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDURATION",
+    "baseType": "xs:duration",
+    "description": "Time duration"
+  },
+  {
+    "name": "IFCDYNAMICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCEARTHWORKSCUTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEARTHWORKSFILLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICCAPACITANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric capacitance measurement"
+  },
+  {
+    "name": "IFCELECTRICCHARGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric charge measurement"
+  },
+  {
+    "name": "IFCELECTRICCONDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric conductance measurement"
+  },
+  {
+    "name": "IFCELECTRICCURRENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric current measurement"
+  },
+  {
+    "name": "IFCELECTRICDISTRIBUTIONBOARDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICFLOWSTORAGEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICFLOWTREATMENTDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICGENERATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICMOTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric resistance measurement"
+  },
+  {
+    "name": "IFCELECTRICTIMECONTROLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELECTRICVOLTAGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Electric voltage measurement"
+  },
+  {
+    "name": "IFCELEMENTASSEMBLYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCELEMENTCOMPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCENERGYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCENGINETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATIVECOOLERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVAPORATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVENTTRIGGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEVENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEXTERNALSPATIALELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFACILITYPARTCOMMONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFACILITYUSAGEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFASTENERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFILTERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFIRESUPPRESSIONTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWINSTRUMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFLOWMETERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFONTSTYLE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTVARIANT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFONTWEIGHT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCFOOTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Force measurement"
+  },
+  {
+    "name": "IFCFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Frequency measurement"
+  },
+  {
+    "name": "IFCFURNITURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOGRAPHICELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOMETRICPROJECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGEOTECHNICALSTRATUMTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGLOBALLYUNIQUEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCGLOBALORLOCALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCGRIDTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATEXCHANGERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCHEATFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCHEATINGVALUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Heating value measurement"
+  },
+  {
+    "name": "IFCHUMIDIFIERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIDENTIFIER",
+    "baseType": "xs:string",
+    "description": "Unique identifier string"
+  },
+  {
+    "name": "IFCILLUMINANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Illuminance measurement"
+  },
+  {
+    "name": "IFCIMPACTPROTECTIONDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINDUCTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Inductance measurement"
+  },
+  {
+    "name": "IFCINTEGER",
+    "baseType": "xs:integer",
+    "description": "Whole number"
+  },
+  {
+    "name": "IFCINTEGERCOUNTRATEMEASURE",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCINTERCEPTORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINTERNALOREXTERNALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCINVENTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCIONCONCENTRATIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCISOTHERMALMOISTURECAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Isothermal moisture capacity measurement"
+  },
+  {
+    "name": "IFCJUNCTIONBOXTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCKERBTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCKINEMATICVISCOSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLABEL",
+    "baseType": "xs:string",
+    "description": "Short text string (max 255 characters)"
+  },
+  {
+    "name": "IFCLABORRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLANGUAGEID",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCLAYERSETDIRECTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Length measurement"
+  },
+  {
+    "name": "IFCLIGHTDISTRIBUTIONCURVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTEMISSIONSOURCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLIGHTFIXTURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
     "name": "IFCLINEARFORCEMEASURE",
     "baseType": "xs:double",
     "description": "Linear force measurement"
-  },
-  {
-    "name": "IFCPLANARFORCEMEASURE",
-    "baseType": "xs:double",
-    "description": "Planar force measurement"
-  },
-  {
-    "name": "IFCLINEARSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear stiffness measurement"
-  },
-  {
-    "name": "IFCROTATIONALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Rotational stiffness measurement"
-  },
-  {
-    "name": "IFCWARPINGMOMENTALSTIFFNESSMEASURE",
-    "baseType": "xs:double",
-    "description": "Warping momental stiffness measurement"
-  },
-  {
-    "name": "IFCMODULUSOFELASTICITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Modulus of elasticity measurement"
-  },
-  {
-    "name": "IFCSHEARMODULUSMEASURE",
-    "baseType": "xs:double",
-    "description": "Shear modulus measurement"
-  },
-  {
-    "name": "IFCLINEARDENSITYMEASURE",
-    "baseType": "xs:double",
-    "description": "Linear density measurement"
   },
   {
     "name": "IFCLINEARMOMENTMEASURE",
@@ -300,14 +875,479 @@
     "description": "Linear moment measurement"
   },
   {
-    "name": "IFCPLANARMOMENTMEASURE",
+    "name": "IFCLINEARSTIFFNESSMEASURE",
     "baseType": "xs:double",
-    "description": "Planar moment measurement"
+    "description": "Linear stiffness measurement"
   },
   {
-    "name": "IFCSECTIONMODULUSMEASURE",
+    "name": "IFCLINEARVELOCITYMEASURE",
     "baseType": "xs:double",
-    "description": "Section modulus measurement"
+    "description": "Linear velocity measurement"
+  },
+  {
+    "name": "IFCLIQUIDTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLOADGROUPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLOGICAL",
+    "baseType": "xs:string",
+    "description": "True, False, or Unknown"
+  },
+  {
+    "name": "IFCLOGICALOPERATORENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCLUMINOUSFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous flux measurement"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYDISTRIBUTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCLUMINOUSINTENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Luminous intensity measurement"
+  },
+  {
+    "name": "IFCMAGNETICFLUXDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMAGNETICFLUXMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMARINEFACILITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMARINEPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMASSDENSITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Mass measurement"
+  },
+  {
+    "name": "IFCMASSPERLENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMECHANICALFASTENERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMEDICALDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMOBILETELECOMMUNICATIONSAPPLIANCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMODULUSOFELASTICITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Modulus of elasticity measurement"
+  },
+  {
+    "name": "IFCMODULUSOFLINEARSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFROTATIONALSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMODULUSOFSUBGRADEREACTIONMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOISTUREDIFFUSIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Moisture diffusivity measurement"
+  },
+  {
+    "name": "IFCMOLECULARWEIGHTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCMOMENTOFINERTIAMEASURE",
+    "baseType": "xs:double",
+    "description": "Moment of inertia measurement"
+  },
+  {
+    "name": "IFCMONETARYMEASURE",
+    "baseType": "xs:double",
+    "description": "Monetary measurement"
+  },
+  {
+    "name": "IFCMONTHINYEARNUMBER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCMOORINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCMOTORCONNECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCNAVIGATIONELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCNONNEGATIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNORMALISEDRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCNUMERICMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCOBJECTIVEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOCCUPANTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOPENINGELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCOUTLETTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPARAMETERVALUE",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCPAVEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERFORMANCEHISTORYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERMEABLECOVERINGOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERMITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPHMEASURE",
+    "baseType": "xs:double",
+    "description": "pH measurement"
+  },
+  {
+    "name": "IFCPHYSICALORVIRTUALENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILECONSTRUCTIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPEFITTINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPIPESEGMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPLANARFORCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Planar force measurement"
+  },
+  {
+    "name": "IFCPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Plane angle measurement"
+  },
+  {
+    "name": "IFCPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPOSITIVEINTEGER",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCPOSITIVELENGTHMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVEPLANEANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOSITIVERATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Power measurement"
+  },
+  {
+    "name": "IFCPRESENTABLETEXT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Pressure measurement"
+  },
+  {
+    "name": "IFCPROCEDURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROFILETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTEDORTRUELENGTHENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTIONELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROJECTORDERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROPERTYSETTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETRIPPINGUNITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPROTECTIVEDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPUMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRADIOACTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCRAILINGTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAILWAYPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAILWAYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRAMPTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCRATIOMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCREAL",
+    "baseType": "xs:double",
+    "description": "Decimal number"
+  },
+  {
+    "name": "IFCRECURRENCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREFERENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREFLECTANCEMETHODENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCEDSOILTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARSURFACEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGBARTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCREINFORCINGMESHTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROADPARTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROADTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROLEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROOFTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCROTATIONALFREQUENCYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALMASSMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCROTATIONALSTIFFNESSMEASURE",
+    "baseType": "xs:double",
+    "description": "Rotational stiffness measurement"
+  },
+  {
+    "name": "IFCSANITARYTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   },
   {
     "name": "IFCSECTIONALAREAINTEGRALMEASURE",
@@ -315,8 +1355,443 @@
     "description": "Sectional area integral measurement"
   },
   {
-    "name": "IFCWARPING",
+    "name": "IFCSECTIONMODULUSMEASURE",
     "baseType": "xs:double",
-    "description": "Warping measurement"
+    "description": "Section modulus measurement"
+  },
+  {
+    "name": "IFCSECTIONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSENSORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSEQUENCEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHADINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSHEARMODULUSMEASURE",
+    "baseType": "xs:double",
+    "description": "Shear modulus measurement"
+  },
+  {
+    "name": "IFCSIGNALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSIGNTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSIMPLEPROPERTYTEMPLATETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSLABTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLARDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSOLIDANGLEMEASURE",
+    "baseType": "xs:double",
+    "description": "Solid angle measurement"
+  },
+  {
+    "name": "IFCSOUNDPOWERLEVELMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPOWERMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSURELEVELMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSOUNDPRESSUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCSPACEHEATERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPACETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPATIALZONETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSPECIFICHEATCAPACITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Specific heat capacity measurement"
+  },
+  {
+    "name": "IFCSPECULAREXPONENT",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSPECULARROUGHNESS",
+    "baseType": "xs:double",
+    "description": "Decimal value"
+  },
+  {
+    "name": "IFCSTACKTERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRFLIGHTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTAIRTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTATEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRIPPEDOPTIONAL",
+    "baseType": "xs:boolean",
+    "description": "Boolean value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVEACTIVITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALCURVEMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACEACTIVITYTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSTRUCTURALSURFACEMEMBERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSUBCONTRACTRESOURCETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSURFACEFEATURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSWITCHINGDEVICETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCSYSTEMFURNITUREELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTANKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTASKDURATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTASKTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEMPERATUREGRADIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Temperature gradient measurement"
+  },
+  {
+    "name": "IFCTEMPERATURERATEOFCHANGEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTENDONANCHORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTENDONCONDUITTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTENDONTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTEXT",
+    "baseType": "xs:string",
+    "description": "Long text string"
+  },
+  {
+    "name": "IFCTEXTALIGNMENT",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTDECORATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTFONTNAME",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTEXTTRANSFORMATION",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCTHERMALADMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALCONDUCTIVITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALEXPANSIONCOEFFICIENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALRESISTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCTHERMALTRANSMITTANCEMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermal transmittance measurement"
+  },
+  {
+    "name": "IFCTHERMODYNAMICTEMPERATUREMEASURE",
+    "baseType": "xs:double",
+    "description": "Thermodynamic temperature measurement"
+  },
+  {
+    "name": "IFCTIME",
+    "baseType": "xs:time",
+    "description": "Time value"
+  },
+  {
+    "name": "IFCTIMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Time measurement"
+  },
+  {
+    "name": "IFCTIMESERIESDATATYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTIMESTAMP",
+    "baseType": "xs:integer",
+    "description": "Integer value"
+  },
+  {
+    "name": "IFCTORQUEMEASURE",
+    "baseType": "xs:double",
+    "description": "Torque measurement"
+  },
+  {
+    "name": "IFCTRACKELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTRANSFORMERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTRANSPORTELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCTUBEBUNDLETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYCONTROLELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITARYEQUIPMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCUNITENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCURIREFERENCE",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCVALVETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVAPORPERMEABILITYMEASURE",
+    "baseType": "xs:double",
+    "description": "Vapor permeability measurement"
+  },
+  {
+    "name": "IFCVEHICLETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVIBRATIONDAMPERTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVIBRATIONISOLATORTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVIRTUALELEMENTTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOIDINGFEATURETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCVOLUMEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volume measurement"
+  },
+  {
+    "name": "IFCVOLUMETRICFLOWRATEMEASURE",
+    "baseType": "xs:double",
+    "description": "Volumetric flow rate measurement"
+  },
+  {
+    "name": "IFCWALLTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWARPINGCONSTANTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWARPINGMOMENTMEASURE",
+    "baseType": "xs:double",
+    "description": "Measure value (decimal)"
+  },
+  {
+    "name": "IFCWASTETERMINALTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWELLKNOWNTEXTLITERAL",
+    "baseType": "xs:string",
+    "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCWINDOWPANELOPERATIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWPANELPOSITIONENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWINDOWTYPEPARTITIONINGENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKCALENDARTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKPLANTYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
+  },
+  {
+    "name": "IFCWORKSCHEDULETYPEENUM",
+    "baseType": "xs:string",
+    "description": "Enumeration value"
   }
 ]

--- a/scripts/generate-ids-datatypes.mjs
+++ b/scripts/generate-ids-datatypes.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Generate the valid-IDS-dataType allowlist per IFC schema version, directly
+// from the official buildingSMART IDS specification table.
+//
+// Source of truth (committed alongside this script for provenance):
+//   scripts/ids-datatypes.md
+//   = buildingSMART/IDS · Documentation/ImplementersDocumentation/DataTypes.md
+//     https://github.com/buildingSMART/IDS/blob/development/Documentation/ImplementersDocumentation/DataTypes.md
+//
+// Why this exists: IDS property `dataType` is OPTIONAL, but when present it must
+// be one of the values in this table for the chosen schema version (uppercase).
+// The IDS schema does NOT check that a dataType is the "right" one for a given
+// property — only that it is a member of this list. Our previous hand-curated
+// 64-type list omitted valid measure subtypes (e.g. IFCPOSITIVELENGTHMEASURE),
+// which produced false "invalid datatype" results. See issues #48 / #52.
+//
+// Run with:  node scripts/generate-ids-datatypes.mjs
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..')
+
+const SOURCE = join(__dirname, 'ids-datatypes.md')
+
+// Spec column header -> our generated filename suffix.
+const VERSIONS = [
+  { col: 1, suffix: 'ifc2x3' },
+  { col: 2, suffix: 'ifc4' },
+  { col: 3, suffix: 'ifc4x3_add2' },
+]
+
+const OUT_DIRS = [
+  join(repoRoot, 'lib', 'generated', 'ifc-schema'),
+  join(repoRoot, 'public', 'generated'),
+]
+
+/** Parse the markdown dataType table into rows. */
+function parseTable(md) {
+  const rows = []
+  for (const line of md.split('\n')) {
+    // Only the dataType table rows: "| IFCSOMETHING | ✓ | | ✓ | xs:double |"
+    const m = line.match(/^\|\s*(IFC[A-Z0-9]+)\s*\|(.*)\|\s*$/)
+    if (!m) continue
+    const name = m[1].trim()
+    const cells = m[2].split('|').map((c) => c.trim())
+    if (cells.length < 4) continue
+    const valid = cells.slice(0, 3).map((c) => c.includes('✓'))
+    // Guard against accidentally matching a different table: version cells must
+    // be either a checkmark or empty.
+    const versionCellsClean = cells
+      .slice(0, 3)
+      .every((c) => c === '' || c.includes('✓'))
+    if (!versionCellsClean) continue
+    if (!valid.some(Boolean)) continue
+    const baseType = (cells[3] || '').trim()
+    rows.push({ name, valid, baseType })
+  }
+  return rows
+}
+
+/** Harvest curated human descriptions from the existing generated files. */
+function harvestDescriptions() {
+  const map = new Map()
+  for (const dir of OUT_DIRS) {
+    for (const { suffix } of VERSIONS) {
+      const file = join(dir, `simple-types-${suffix}.json`)
+      if (!existsSync(file)) continue
+      try {
+        const arr = JSON.parse(readFileSync(file, 'utf8'))
+        for (const t of arr) {
+          if (t?.name && t?.description && !map.has(t.name)) {
+            map.set(t.name.toUpperCase(), t.description)
+          }
+        }
+      } catch {
+        /* ignore malformed pre-existing file */
+      }
+    }
+  }
+  return map
+}
+
+function fallbackDescription(name, baseType) {
+  if (name.endsWith('ENUM')) return 'Enumeration value'
+  switch (baseType) {
+    case 'xs:double':
+      return name.endsWith('MEASURE') ? 'Measure value (decimal)' : 'Decimal value'
+    case 'xs:integer':
+      return 'Integer value'
+    case 'xs:boolean':
+      return 'Boolean value'
+    case 'xs:date':
+    case 'xs:dateTime':
+    case 'xs:time':
+    case 'xs:duration':
+      return 'Date/time value'
+    case 'xs:string':
+      return 'Text or identifier value'
+    case '':
+    case undefined:
+      return 'Binary value'
+    default:
+      return `${baseType} value`
+  }
+}
+
+function main() {
+  const md = readFileSync(SOURCE, 'utf8')
+  const rows = parseTable(md)
+  if (rows.length < 100) {
+    throw new Error(`Parsed only ${rows.length} dataType rows — source table looks wrong`)
+  }
+  const descriptions = harvestDescriptions()
+
+  for (const { col, suffix } of VERSIONS) {
+    const idx = col - 1
+    const list = rows
+      .filter((r) => r.valid[idx])
+      .map((r) => ({
+        name: r.name,
+        baseType: r.baseType,
+        description: descriptions.get(r.name) || fallbackDescription(r.name, r.baseType),
+      }))
+
+    const json = JSON.stringify(list, null, 2) + '\n'
+    for (const dir of OUT_DIRS) {
+      writeFileSync(join(dir, `simple-types-${suffix}.json`), json)
+    }
+    const hasPos = list.some((t) => t.name === 'IFCPOSITIVELENGTHMEASURE')
+    console.log(`  ${suffix}: ${list.length} datatypes (IFCPOSITIVELENGTHMEASURE: ${hasPos ? 'yes' : 'NO'})`)
+  }
+  console.log(`Done. Parsed ${rows.length} rows from ${SOURCE}`)
+}
+
+main()

--- a/scripts/ids-datatypes.md
+++ b/scripts/ids-datatypes.md
@@ -1,0 +1,427 @@
+# Type constraining
+
+## DataTypes
+
+Property dataTypes can be set to any values according to the following table.
+
+Columns of the table determine the validity of the type depending on the schema version and the required `xs:base` type for any `xs:restriction` constraint.
+
+| dataType                                      | Ifc2x3  | Ifc4    | Ifc4x3  | Restriction base type |
+| --------------------------------------------- | :-----: | :-----: | :-----: | --------------------- |
+| IFCABSORBEDDOSEMEASURE                        |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCACCELERATIONMEASURE                        |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCACTIONREQUESTTYPEENUM                      |         |    ✓    |    ✓    | xs:string             |
+| IFCACTIONSOURCETYPEENUM                       |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCACTIONTYPEENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCACTUATORTYPEENUM                           |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCADDRESSTYPEENUM                            |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCAIRTERMINALBOXTYPEENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCAIRTERMINALTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCAIRTOAIRHEATRECOVERYTYPEENUM               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCALARMTYPEENUM                              |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCALIGNMENTCANTSEGMENTTYPEENUM               |         |         |    ✓    | xs:string             |
+| IFCALIGNMENTHORIZONTALSEGMENTTYPEENUM         |         |         |    ✓    | xs:string             |
+| IFCALIGNMENTTYPEENUM                          |         |         |    ✓    | xs:string             |
+| IFCALIGNMENTVERTICALSEGMENTTYPEENUM           |         |         |    ✓    | xs:string             |
+| IFCAMOUNTOFSUBSTANCEMEASURE                   |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCANALYSISMODELTYPEENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCANALYSISTHEORYTYPEENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCANGULARVELOCITYMEASURE                     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCANNOTATIONTYPEENUM                         |         |         |    ✓    | xs:string             |
+| IFCAREADENSITYMEASURE                         |         |    ✓    |    ✓    | xs:double             |
+| IFCAREAMEASURE                                |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCARITHMETICOPERATORENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCASSEMBLYPLACEENUM                          |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCAUDIOVISUALAPPLIANCETYPEENUM               |         |    ✓    |    ✓    | xs:string             |
+| IFCBEAMTYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCBEARINGTYPEENUM                            |         |         |    ✓    | xs:string             |
+| IFCBENCHMARKENUM                              |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCBINARY                                     |         |    ✓    |    ✓    |                       |
+| IFCBOILERTYPEENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCBOOLEAN                                    |    ✓    |    ✓    |    ✓    | xs:boolean            |
+| IFCBOXALIGNMENT                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCBRIDGEPARTTYPEENUM                         |         |         |    ✓    | xs:string             |
+| IFCBRIDGETYPEENUM                             |         |         |    ✓    | xs:string             |
+| IFCBUILDINGELEMENTPARTTYPEENUM                |         |    ✓    |    ✓    | xs:string             |
+| IFCBUILDINGELEMENTPROXYTYPEENUM               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCBUILDINGSYSTEMTYPEENUM                     |         |    ✓    |    ✓    | xs:string             |
+| IFCBUILTSYSTEMTYPEENUM                        |         |         |    ✓    | xs:string             |
+| IFCBURNERTYPEENUM                             |         |    ✓    |    ✓    | xs:string             |
+| IFCCABLECARRIERFITTINGTYPEENUM                |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCABLECARRIERSEGMENTTYPEENUM                |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCABLEFITTINGTYPEENUM                       |         |    ✓    |    ✓    | xs:string             |
+| IFCCABLESEGMENTTYPEENUM                       |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCAISSONFOUNDATIONTYPEENUM                  |         |         |    ✓    | xs:string             |
+| IFCCARDINALPOINTREFERENCE                     |         |    ✓    |    ✓    | xs:integer            |
+| IFCCHANGEACTIONENUM                           |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCHILLERTYPEENUM                            |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCHIMNEYTYPEENUM                            |         |    ✓    |    ✓    | xs:string             |
+| IFCCOILTYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCOLUMNTYPEENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCOMMUNICATIONSAPPLIANCETYPEENUM            |         |    ✓    |    ✓    | xs:string             |
+| IFCCOMPLEXPROPERTYTEMPLATETYPEENUM            |         |    ✓    |    ✓    | xs:string             |
+| IFCCOMPRESSORTYPEENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCONDENSERTYPEENUM                          |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCONNECTIONTYPEENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCONSTRAINTENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCONSTRUCTIONEQUIPMENTRESOURCETYPEENUM      |         |    ✓    |    ✓    | xs:string             |
+| IFCCONSTRUCTIONMATERIALRESOURCETYPEENUM       |         |    ✓    |    ✓    | xs:string             |
+| IFCCONSTRUCTIONPRODUCTRESOURCETYPEENUM        |         |    ✓    |    ✓    | xs:string             |
+| IFCCONTEXTDEPENDENTMEASURE                    |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCCONTROLLERTYPEENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCONVEYORSEGMENTTYPEENUM                    |         |         |    ✓    | xs:string             |
+| IFCCOOLEDBEAMTYPEENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCOOLINGTOWERTYPEENUM                       |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCOSTITEMTYPEENUM                           |         |    ✓    |    ✓    | xs:string             |
+| IFCCOSTSCHEDULETYPEENUM                       |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCOUNTMEASURE                               |    ✓    |    ✓    |    ✓    | xs:integer            |
+| IFCCOURSETYPEENUM                             |         |         |    ✓    | xs:string             |
+| IFCCOVERINGTYPEENUM                           |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCREWRESOURCETYPEENUM                       |         |    ✓    |    ✓    | xs:string             |
+| IFCCURRENCYENUM                               |    ✓    |         |         | xs:string             |
+| IFCCURTAINWALLTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCCURVATUREMEASURE                           |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCCURVEINTERPOLATIONENUM                     |         |    ✓    |    ✓    | xs:string             |
+| IFCDAMPERTYPEENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDATAORIGINENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDATE                                       |         |    ✓    |    ✓    | xs:date               |
+| IFCDATETIME                                   |         |    ✓    |    ✓    | xs:dateTime           |
+| IFCDAYINMONTHNUMBER                           |    ✓    |    ✓    |    ✓    | xs:integer            |
+| IFCDAYINWEEKNUMBER                            |         |    ✓    |    ✓    | xs:integer            |
+| IFCDAYLIGHTSAVINGHOUR                         |    ✓    |         |         | xs:integer            |
+| IFCDERIVEDUNITENUM                            |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDESCRIPTIVEMEASURE                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDIMENSIONCOUNT                             |    ✓    |    ✓    |    ✓    | xs:integer            |
+| IFCDIRECTIONSENSEENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDISCRETEACCESSORYTYPEENUM                  |         |    ✓    |    ✓    | xs:string             |
+| IFCDISTRIBUTIONBOARDTYPEENUM                  |         |         |    ✓    | xs:string             |
+| IFCDISTRIBUTIONCHAMBERELEMENTTYPEENUM         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDISTRIBUTIONPORTTYPEENUM                   |         |    ✓    |    ✓    | xs:string             |
+| IFCDISTRIBUTIONSYSTEMENUM                     |         |    ✓    |    ✓    | xs:string             |
+| IFCDOCUMENTCONFIDENTIALITYENUM                |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDOCUMENTSTATUSENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDOORPANELOPERATIONENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDOORPANELPOSITIONENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDOORSTYLECONSTRUCTIONENUM                  |    ✓    |    ✓    |         | xs:string             |
+| IFCDOORSTYLEOPERATIONENUM                     |    ✓    |    ✓    |         | xs:string             |
+| IFCDOORTYPEENUM                               |         |    ✓    |    ✓    | xs:string             |
+| IFCDOORTYPEOPERATIONENUM                      |         |    ✓    |    ✓    | xs:string             |
+| IFCDOSEEQUIVALENTMEASURE                      |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCDUCTFITTINGTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDUCTSEGMENTTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDUCTSILENCERTYPEENUM                       |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCDURATION                                   |         |    ✓    |    ✓    | xs:duration           |
+| IFCDYNAMICVISCOSITYMEASURE                    |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCEARTHWORKSCUTTYPEENUM                      |         |         |    ✓    | xs:string             |
+| IFCEARTHWORKSFILLTYPEENUM                     |         |         |    ✓    | xs:string             |
+| IFCELECTRICAPPLIANCETYPEENUM                  |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCELECTRICCAPACITANCEMEASURE                 |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCELECTRICCHARGEMEASURE                      |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCELECTRICCONDUCTANCEMEASURE                 |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCELECTRICCURRENTENUM                        |    ✓    |         |         | xs:string             |
+| IFCELECTRICCURRENTMEASURE                     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCELECTRICDISTRIBUTIONBOARDTYPEENUM          |         |    ✓    |    ✓    | xs:string             |
+| IFCELECTRICDISTRIBUTIONPOINTFUNCTIONENUM      |    ✓    |         |         | xs:string             |
+| IFCELECTRICFLOWSTORAGEDEVICETYPEENUM          |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCELECTRICFLOWTREATMENTDEVICETYPEENUM        |         |         |    ✓    | xs:string             |
+| IFCELECTRICGENERATORTYPEENUM                  |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCELECTRICHEATERTYPEENUM                     |    ✓    |         |         | xs:string             |
+| IFCELECTRICMOTORTYPEENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCELECTRICRESISTANCEMEASURE                  |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCELECTRICTIMECONTROLTYPEENUM                |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCELECTRICVOLTAGEMEASURE                     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCELEMENTASSEMBLYTYPEENUM                    |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCELEMENTCOMPOSITIONENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCENERGYMEASURE                              |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCENERGYSEQUENCEENUM                         |    ✓    |         |         | xs:string             |
+| IFCENGINETYPEENUM                             |         |    ✓    |    ✓    | xs:string             |
+| IFCENVIRONMENTALIMPACTCATEGORYENUM            |    ✓    |         |         | xs:string             |
+| IFCEVAPORATIVECOOLERTYPEENUM                  |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCEVAPORATORTYPEENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCEVENTTRIGGERTYPEENUM                       |         |    ✓    |    ✓    | xs:string             |
+| IFCEVENTTYPEENUM                              |         |    ✓    |    ✓    | xs:string             |
+| IFCEXTERNALSPATIALELEMENTTYPEENUM             |         |    ✓    |    ✓    | xs:string             |
+| IFCFACILITYPARTCOMMONTYPEENUM                 |         |         |    ✓    | xs:string             |
+| IFCFACILITYUSAGEENUM                          |         |         |    ✓    | xs:string             |
+| IFCFANTYPEENUM                                |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFASTENERTYPEENUM                           |         |    ✓    |    ✓    | xs:string             |
+| IFCFILTERTYPEENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFIRESUPPRESSIONTERMINALTYPEENUM            |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFLOWDIRECTIONENUM                          |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFLOWINSTRUMENTTYPEENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFLOWMETERTYPEENUM                          |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFONTSTYLE                                  |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFONTVARIANT                                |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFONTWEIGHT                                 |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFOOTINGTYPEENUM                            |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCFORCEMEASURE                               |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCFREQUENCYMEASURE                           |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCFURNITURETYPEENUM                          |         |    ✓    |    ✓    | xs:string             |
+| IFCGASTERMINALTYPEENUM                        |    ✓    |         |         | xs:string             |
+| IFCGEOGRAPHICELEMENTTYPEENUM                  |         |    ✓    |    ✓    | xs:string             |
+| IFCGEOMETRICPROJECTIONENUM                    |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCGEOTECHNICALSTRATUMTYPEENUM                |         |         |    ✓    | xs:string             |
+| IFCGLOBALLYUNIQUEID                           |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCGLOBALORLOCALENUM                          |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCGRIDTYPEENUM                               |         |    ✓    |    ✓    | xs:string             |
+| IFCHEATEXCHANGERTYPEENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCHEATFLUXDENSITYMEASURE                     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCHEATINGVALUEMEASURE                        |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCHOURINDAY                                  |    ✓    |         |         | xs:integer            |
+| IFCHUMIDIFIERTYPEENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCIDENTIFIER                                 |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCILLUMINANCEMEASURE                         |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCIMPACTPROTECTIONDEVICETYPEENUM             |         |         |    ✓    | xs:string             |
+| IFCINDUCTANCEMEASURE                          |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCINTEGER                                    |    ✓    |    ✓    |    ✓    | xs:integer            |
+| IFCINTEGERCOUNTRATEMEASURE                    |    ✓    |    ✓    |    ✓    | xs:integer            |
+| IFCINTERCEPTORTYPEENUM                        |         |    ✓    |    ✓    | xs:string             |
+| IFCINTERNALOREXTERNALENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCINVENTORYTYPEENUM                          |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCIONCONCENTRATIONMEASURE                    |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCISOTHERMALMOISTURECAPACITYMEASURE          |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCJUNCTIONBOXTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCKERBTYPEENUM                               |         |         |    ✓    | xs:string             |
+| IFCKINEMATICVISCOSITYMEASURE                  |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCLABEL                                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCLABORRESOURCETYPEENUM                      |         |    ✓    |    ✓    | xs:string             |
+| IFCLAMPTYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCLANGUAGEID                                 |         |    ✓    |    ✓    | xs:string             |
+| IFCLAYERSETDIRECTIONENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCLENGTHMEASURE                              |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCLIGHTDISTRIBUTIONCURVEENUM                 |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCLIGHTEMISSIONSOURCEENUM                    |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCLIGHTFIXTURETYPEENUM                       |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCLINEARFORCEMEASURE                         |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCLINEARMOMENTMEASURE                        |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCLINEARSTIFFNESSMEASURE                     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCLINEARVELOCITYMEASURE                      |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCLIQUIDTERMINALTYPEENUM                     |         |         |    ✓    | xs:string             |
+| IFCLOADGROUPTYPEENUM                          |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCLOGICAL                                    |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCLOGICALOPERATORENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCLUMINOUSFLUXMEASURE                        |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCLUMINOUSINTENSITYDISTRIBUTIONMEASURE       |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCLUMINOUSINTENSITYMEASURE                   |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMAGNETICFLUXDENSITYMEASURE                 |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMAGNETICFLUXMEASURE                        |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMARINEFACILITYTYPEENUM                     |         |         |    ✓    | xs:string             |
+| IFCMARINEPARTTYPEENUM                         |         |         |    ✓    | xs:string             |
+| IFCMASSDENSITYMEASURE                         |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMASSFLOWRATEMEASURE                        |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMASSMEASURE                                |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMASSPERLENGTHMEASURE                       |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMECHANICALFASTENERTYPEENUM                 |         |    ✓    |    ✓    | xs:string             |
+| IFCMEDICALDEVICETYPEENUM                      |         |    ✓    |    ✓    | xs:string             |
+| IFCMEMBERTYPEENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCMINUTEINHOUR                               |    ✓    |         |         | xs:integer            |
+| IFCMOBILETELECOMMUNICATIONSAPPLIANCETYPEENUM  |         |         |    ✓    | xs:string             |
+| IFCMODULUSOFELASTICITYMEASURE                 |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMODULUSOFLINEARSUBGRADEREACTIONMEASURE     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMODULUSOFROTATIONALSUBGRADEREACTIONMEASURE |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMODULUSOFSUBGRADEREACTIONMEASURE           |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMOISTUREDIFFUSIVITYMEASURE                 |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMOLECULARWEIGHTMEASURE                     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMOMENTOFINERTIAMEASURE                     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMONETARYMEASURE                            |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCMONTHINYEARNUMBER                          |    ✓    |    ✓    |    ✓    | xs:integer            |
+| IFCMOORINGDEVICETYPEENUM                      |         |         |    ✓    | xs:string             |
+| IFCMOTORCONNECTIONTYPEENUM                    |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCNAVIGATIONELEMENTTYPEENUM                  |         |         |    ✓    | xs:string             |
+| IFCNONNEGATIVELENGTHMEASURE                   |         |    ✓    |    ✓    | xs:double             |
+| IFCNORMALISEDRATIOMEASURE                     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCNULLSTYLE                                  |    ✓    |    ✓    |         | xs:string             |
+| IFCNUMERICMEASURE                             |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCOBJECTIVEENUM                              |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCOBJECTTYPEENUM                             |    ✓    |    ✓    |         | xs:string             |
+| IFCOCCUPANTTYPEENUM                           |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCOPENINGELEMENTTYPEENUM                     |         |    ✓    |    ✓    | xs:string             |
+| IFCOUTLETTYPEENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPARAMETERVALUE                             |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCPAVEMENTTYPEENUM                           |         |         |    ✓    | xs:string             |
+| IFCPERFORMANCEHISTORYTYPEENUM                 |         |    ✓    |    ✓    | xs:string             |
+| IFCPERMEABLECOVERINGOPERATIONENUM             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPERMITTYPEENUM                             |         |    ✓    |    ✓    | xs:string             |
+| IFCPHMEASURE                                  |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCPHYSICALORVIRTUALENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPILECONSTRUCTIONENUM                       |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPILETYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPIPEFITTINGTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPIPESEGMENTTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPLANARFORCEMEASURE                         |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCPLANEANGLEMEASURE                          |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCPLATETYPEENUM                              |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPOSITIVEINTEGER                            |         |    ✓    |    ✓    | xs:integer            |
+| IFCPOSITIVELENGTHMEASURE                      |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCPOSITIVEPLANEANGLEMEASURE                  |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCPOSITIVERATIOMEASURE                       |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCPOWERMEASURE                               |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCPRESENTABLETEXT                            |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPRESSUREMEASURE                            |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCPROCEDURETYPEENUM                          |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPROFILETYPEENUM                            |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPROJECTEDORTRUELENGTHENUM                  |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPROJECTIONELEMENTTYPEENUM                  |         |    ✓    |    ✓    | xs:string             |
+| IFCPROJECTORDERRECORDTYPEENUM                 |    ✓    |         |         | xs:string             |
+| IFCPROJECTORDERTYPEENUM                       |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPROPERTYSETTEMPLATETYPEENUM                |         |    ✓    |    ✓    | xs:string             |
+| IFCPROPERTYSOURCEENUM                         |    ✓    |         |         | xs:string             |
+| IFCPROTECTIVEDEVICETRIPPINGUNITTYPEENUM       |         |    ✓    |    ✓    | xs:string             |
+| IFCPROTECTIVEDEVICETYPEENUM                   |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCPUMPTYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCRADIOACTIVITYMEASURE                       |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCRAILINGTYPEENUM                            |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCRAILTYPEENUM                               |         |         |    ✓    | xs:string             |
+| IFCRAILWAYPARTTYPEENUM                        |         |         |    ✓    | xs:string             |
+| IFCRAILWAYTYPEENUM                            |         |         |    ✓    | xs:string             |
+| IFCRAMPFLIGHTTYPEENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCRAMPTYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCRATIOMEASURE                               |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCREAL                                       |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCRECURRENCETYPEENUM                         |         |    ✓    |    ✓    | xs:string             |
+| IFCREFERENTTYPEENUM                           |         |    ✓    |    ✓    | xs:string             |
+| IFCREFLECTANCEMETHODENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCREINFORCEDSOILTYPEENUM                     |         |         |    ✓    | xs:string             |
+| IFCREINFORCINGBARROLEENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCREINFORCINGBARSURFACEENUM                  |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCREINFORCINGBARTYPEENUM                     |         |    ✓    |    ✓    | xs:string             |
+| IFCREINFORCINGMESHTYPEENUM                    |         |    ✓    |    ✓    | xs:string             |
+| IFCRESOURCECONSUMPTIONENUM                    |    ✓    |         |         | xs:string             |
+| IFCRIBPLATEDIRECTIONENUM                      |    ✓    |         |         | xs:string             |
+| IFCROADPARTTYPEENUM                           |         |         |    ✓    | xs:string             |
+| IFCROADTYPEENUM                               |         |         |    ✓    | xs:string             |
+| IFCROLEENUM                                   |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCROOFTYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCROTATIONALFREQUENCYMEASURE                 |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCROTATIONALMASSMEASURE                      |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCROTATIONALSTIFFNESSMEASURE                 |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSANITARYTERMINALTYPEENUM                   |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSECONDINMINUTE                             |    ✓    |         |         | xs:double             |
+| IFCSECTIONALAREAINTEGRALMEASURE               |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSECTIONMODULUSMEASURE                      |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSECTIONTYPEENUM                            |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSENSORTYPEENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSEQUENCEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSERVICELIFEFACTORTYPEENUM                  |    ✓    |         |         | xs:string             |
+| IFCSERVICELIFETYPEENUM                        |    ✓    |         |         | xs:string             |
+| IFCSHADINGDEVICETYPEENUM                      |         |    ✓    |    ✓    | xs:string             |
+| IFCSHEARMODULUSMEASURE                        |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSIGNALTYPEENUM                             |         |         |    ✓    | xs:string             |
+| IFCSIGNTYPEENUM                               |         |         |    ✓    | xs:string             |
+| IFCSIMPLEPROPERTYTEMPLATETYPEENUM             |         |    ✓    |    ✓    | xs:string             |
+| IFCSLABTYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSOLARDEVICETYPEENUM                        |         |    ✓    |    ✓    | xs:string             |
+| IFCSOLIDANGLEMEASURE                          |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSOUNDPOWERLEVELMEASURE                     |         |    ✓    |    ✓    | xs:double             |
+| IFCSOUNDPOWERMEASURE                          |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSOUNDPRESSURELEVELMEASURE                  |         |    ✓    |    ✓    | xs:double             |
+| IFCSOUNDPRESSUREMEASURE                       |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSOUNDSCALEENUM                             |    ✓    |         |         | xs:string             |
+| IFCSPACEHEATERTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSPACETYPEENUM                              |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSPATIALZONETYPEENUM                        |         |    ✓    |    ✓    | xs:string             |
+| IFCSPECIFICHEATCAPACITYMEASURE                |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSPECULAREXPONENT                           |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSPECULARROUGHNESS                          |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCSTACKTERMINALTYPEENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSTAIRFLIGHTTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSTAIRTYPEENUM                              |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSTATEENUM                                  |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSTRIPPEDOPTIONAL                           |         |    ✓    |    ✓    | xs:boolean            |
+| IFCSTRUCTURALCURVEACTIVITYTYPEENUM            |         |    ✓    |    ✓    | xs:string             |
+| IFCSTRUCTURALCURVEMEMBERTYPEENUM              |         |    ✓    |    ✓    | xs:string             |
+| IFCSTRUCTURALCURVETYPEENUM                    |    ✓    |         |         | xs:string             |
+| IFCSTRUCTURALSURFACEACTIVITYTYPEENUM          |         |    ✓    |    ✓    | xs:string             |
+| IFCSTRUCTURALSURFACEMEMBERTYPEENUM            |         |    ✓    |    ✓    | xs:string             |
+| IFCSTRUCTURALSURFACETYPEENUM                  |    ✓    |         |         | xs:string             |
+| IFCSUBCONTRACTRESOURCETYPEENUM                |         |    ✓    |    ✓    | xs:string             |
+| IFCSURFACEFEATURETYPEENUM                     |         |    ✓    |    ✓    | xs:string             |
+| IFCSURFACETEXTUREENUM                         |    ✓    |         |         | xs:string             |
+| IFCSWITCHINGDEVICETYPEENUM                    |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCSYSTEMFURNITUREELEMENTTYPEENUM             |         |    ✓    |    ✓    | xs:string             |
+| IFCTANKTYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTASKDURATIONENUM                           |         |    ✓    |    ✓    | xs:string             |
+| IFCTASKTYPEENUM                               |         |    ✓    |    ✓    | xs:string             |
+| IFCTEMPERATUREGRADIENTMEASURE                 |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCTEMPERATURERATEOFCHANGEMEASURE             |         |    ✓    |    ✓    | xs:double             |
+| IFCTENDONANCHORTYPEENUM                       |         |    ✓    |    ✓    | xs:string             |
+| IFCTENDONCONDUITTYPEENUM                      |         |         |    ✓    | xs:string             |
+| IFCTENDONTYPEENUM                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTEXT                                       |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTEXTALIGNMENT                              |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTEXTDECORATION                             |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTEXTFONTNAME                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTEXTTRANSFORMATION                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTHERMALADMITTANCEMEASURE                   |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCTHERMALCONDUCTIVITYMEASURE                 |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCTHERMALEXPANSIONCOEFFICIENTMEASURE         |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCTHERMALLOADSOURCEENUM                      |    ✓    |         |         | xs:string             |
+| IFCTHERMALLOADTYPEENUM                        |    ✓    |         |         | xs:string             |
+| IFCTHERMALRESISTANCEMEASURE                   |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCTHERMALTRANSMITTANCEMEASURE                |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCTHERMODYNAMICTEMPERATUREMEASURE            |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCTIME                                       |         |    ✓    |    ✓    | xs:time               |
+| IFCTIMEMEASURE                                |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCTIMESERIESDATATYPEENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTIMESERIESSCHEDULETYPEENUM                 |    ✓    |         |         | xs:string             |
+| IFCTIMESTAMP                                  |    ✓    |    ✓    |    ✓    | xs:integer            |
+| IFCTORQUEMEASURE                              |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCTRACKELEMENTTYPEENUM                       |         |         |    ✓    | xs:string             |
+| IFCTRANSFORMERTYPEENUM                        |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTRANSPORTELEMENTTYPEENUM                   |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCTUBEBUNDLETYPEENUM                         |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCUNITARYCONTROLELEMENTTYPEENUM              |         |    ✓    |    ✓    | xs:string             |
+| IFCUNITARYEQUIPMENTTYPEENUM                   |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCUNITENUM                                   |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCURIREFERENCE                               |         |    ✓    |    ✓    | xs:string             |
+| IFCVALVETYPEENUM                              |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCVAPORPERMEABILITYMEASURE                   |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCVEHICLETYPEENUM                            |         |         |    ✓    | xs:string             |
+| IFCVIBRATIONDAMPERTYPEENUM                    |         |         |    ✓    | xs:string             |
+| IFCVIBRATIONISOLATORTYPEENUM                  |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCVIRTUALELEMENTTYPEENUM                     |         |         |    ✓    | xs:string             |
+| IFCVOIDINGFEATURETYPEENUM                     |         |    ✓    |    ✓    | xs:string             |
+| IFCVOLUMEMEASURE                              |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCVOLUMETRICFLOWRATEMEASURE                  |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCWALLTYPEENUM                               |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCWARPINGCONSTANTMEASURE                     |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCWARPINGMOMENTMEASURE                       |    ✓    |    ✓    |    ✓    | xs:double             |
+| IFCWASTETERMINALTYPEENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCWELLKNOWNTEXTLITERAL                       |         |         |    ✓    | xs:string             |
+| IFCWINDOWPANELOPERATIONENUM                   |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCWINDOWPANELPOSITIONENUM                    |    ✓    |    ✓    |    ✓    | xs:string             |
+| IFCWINDOWSTYLECONSTRUCTIONENUM                |    ✓    |    ✓    |         | xs:string             |
+| IFCWINDOWSTYLEOPERATIONENUM                   |    ✓    |    ✓    |         | xs:string             |
+| IFCWINDOWTYPEENUM                             |         |    ✓    |    ✓    | xs:string             |
+| IFCWINDOWTYPEPARTITIONINGENUM                 |         |    ✓    |    ✓    | xs:string             |
+| IFCWORKCALENDARTYPEENUM                       |         |    ✓    |    ✓    | xs:string             |
+| IFCWORKCONTROLTYPEENUM                        |    ✓    |         |         | xs:string             |
+| IFCWORKPLANTYPEENUM                           |         |    ✓    |    ✓    | xs:string             |
+| IFCWORKSCHEDULETYPEENUM                       |         |    ✓    |    ✓    | xs:string             |
+| IFCYEARNUMBER                                 |    ✓    |         |         | xs:integer            |
+
+Please note that [IFCSTRIPPEDOPTIONAL](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcStrippedOptional.htm) is a special data type that should never be instantiated, but it is listed here for schema tolerance reasons.
+
+## XML base types
+
+The list of valid XML base types for the `base` attribute of `xs:restriction`, the associated regex expression to check for the validity of string representation, and the allowed nodes inside the `xs:restriction` are as follows:
+
+| Base type   | Value string regex constraint                                                                                                         | annotation    | pattern       | enumeration   | minLength     | maxLength     | length        | minExclusive  | maxExclusive  | minInclusive  | maxInclusive  |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------- | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: |
+| xs:boolean  | <code>^(true&#124;false&#124;0&#124;1)$</code>                                                                                        |       ✓       |       ✓       |               |               |               |               |               |               |               |               |
+| xs:date     | <code>^\d{4}-\d{2}-\d{2}(Z&#124;(&#91;+-&#93;\d{2}:\d{2}))?$</code>                                                                   |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |
+| xs:dateTime | <code>^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z&#124;(&#91;+-&#93;\d{2}:\d{2}))?$</code>                                         |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |
+| xs:double   | <code>^(&#91;-+&#93;?&#91;0-9&#93;*\.?&#91;0-9&#93;*(&#91;eE&#93;&#91;-+&#93;?&#91;0-9&#93;+)?&#124;NaN&#124;\+INF&#124;-INF)$</code> |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |
+| xs:duration | <code>^&#91;-+&#93;?P(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+S)?)?$</code>                                                           |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |
+| xs:integer  | <code>^&#91;+-&#93;?(\d+)$</code>                                                                                                     |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |
+| xs:string   | <code>^.*$</code>                                                                                                                     |       ✓       |       ✓       |       ✓       |       ✓       |       ✓       |       ✓       |               |               |               |               |
+| xs:time     | <code>^\d{2}:\d{2}:\d{2}(\.\d+)?(Z&#124;(&#91;+-&#93;\d{2}:\d{2}))?$</code>                                                           |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |
+
+For example:
+
+- To specify numbers: you must use a dot as the decimal separator, and not use a thousands separator (e.g. `4.2` is valid, but `1.234,5` is invalid). Scientific notation is allowed (e.g. `1e3` to represent `1000`).
+- To specify a boolean: valid values are `true` or `false`, `0`, or `1`.
+
+## Notes
+
+Please note, this document has been automatically generated via the [IDS Audit Tool repository](https://github.com/buildingSMART/IDS-Audit-tool), any changes should be initiated there.

--- a/scripts/psd/fetch-and-parse-psd.py
+++ b/scripts/psd/fetch-and-parse-psd.py
@@ -23,9 +23,11 @@ GITHUB_RAW_BASE = "https://raw.githubusercontent.com/buildingSMART/IFC4.3.x-deve
 GITHUB_API_URL = "https://api.github.com/repos/buildingSMART/IFC4.3.x-development/contents/reference_schemas/psd"
 OUTPUT_DIR = Path(__file__).parent.parent.parent / "lib" / "generated" / "ifc-schema"
 
-# Valid IFC simple types (from our generated schema)
-# Data types in PSD files must be mapped to these
-VALID_SIMPLE_TYPES = {
+# Fallback list of valid IFC simple types, used only if the generated schema
+# allowlist can't be read. The authoritative source is the generated
+# simple-types-*.json (derived from the official buildingSMART IDS DataTypes
+# table); see _load_authoritative_simple_types() below.
+_FALLBACK_SIMPLE_TYPES = {
     "IFCLABEL", "IFCTEXT", "IFCBOOLEAN", "IFCINTEGER", "IFCREAL",
     "IFCIDENTIFIER", "IFCLOGICAL", "IFCDATETIME", "IFCDATE", "IFCTIME",
     "IFCDURATION", "IFCLENGTHMEASURE", "IFCAREAMEASURE", "IFCVOLUMEMEASURE",
@@ -53,7 +55,39 @@ VALID_SIMPLE_TYPES = {
     "IFCSECTIONALAREAINTEGRALMEASURE", "IFCWARPING",
 }
 
-# Map non-standard type names to valid ones
+
+def _load_authoritative_simple_types() -> set:
+    """Load the valid IDS datatype list from the generated schema.
+
+    This is the same per-version allowlist the app validates against, derived
+    from the official buildingSMART IDS DataTypes table. Loading it here (rather
+    than the old hardcoded subset) means valid measure subtypes such as
+    IFCPOSITIVELENGTHMEASURE are recognised and therefore preserved verbatim by
+    normalize_type(), instead of being collapsed to a broader base type. See
+    issues #48 / #52.
+    """
+    generated = Path(__file__).resolve().parents[2] / "lib" / "generated" / "ifc-schema"
+    names: set = set()
+    for suffix in ("ifc2x3", "ifc4", "ifc4x3_add2"):
+        path = generated / f"simple-types-{suffix}.json"
+        try:
+            with open(path) as fh:
+                for entry in json.load(fh):
+                    if entry.get("name"):
+                        names.add(entry["name"].upper())
+        except (OSError, ValueError):
+            continue
+    return names
+
+
+# Authoritative set of valid IDS datatypes. normalize_type() returns any of
+# these verbatim (preserving subtypes); the mapping below is only consulted for
+# names that are NOT valid IDS datatypes (legacy aliases / typos).
+VALID_SIMPLE_TYPES = _load_authoritative_simple_types() or _FALLBACK_SIMPLE_TYPES
+
+# Map non-standard type names to valid ones. NOTE: normalize_type() checks
+# VALID_SIMPLE_TYPES *first*, so entries here for names that ARE valid IDS
+# datatypes (e.g. IFCPOSITIVELENGTHMEASURE) are inert and kept only for history.
 TYPE_NORMALIZATION = {
     "IFCPOSITIVERATIOMEASURE": "IFCREAL",
     "IFCNORMALISEDRATIOMEASURE": "IFCREAL",


### PR DESCRIPTION
## Problem

idsedit.com reported a **false error** for valid IDS files. The reported case (from a public review of Bane NOR's IFC4x3 IDS files): a property using `IfcPositiveLengthMeasure` for `Pset_ConcreteElementGeneral.ConcreteCover` was flagged as wrong, demanding `IfcLengthMeasure`. Per the [IFC4x3 schema](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/Pset_ConcreteElementGeneral.htm) `IfcPositiveLengthMeasure` is correct, so the IDS was valid and the tool was wrong.

## Root cause

Three linked issues, all collapsing IFC measure subtypes:

1. The valid-datatype allowlist (`simple-types-*.json`) was a hand-curated **64-type subset, byte-identical across all IFC versions**, that omitted every measure subtype (`IFCPOSITIVELENGTHMEASURE`, `IFCNONNEGATIVELENGTHMEASURE`, `IFCNORMALISEDRATIOMEASURE`, …). It also fed the inspector dropdown, so the subtypes weren't even selectable.
2. The PSD generator (`scripts/psd/fetch-and-parse-psd.py`) collapsed subtypes to base types (`IFCPOSITIVELENGTHMEASURE → IFCLENGTHMEASURE`), so the generated pset data said `ConcreteCover = IFCLENGTHMEASURE`.
3. The property-vs-pset-template check emitted a **blocking error**, which isn't even an IDS rule.

## What the standard says

Per the bS IDS spec, a property `dataType` is **optional**; if present it only has to be **a member of the allowed datatype list for the schema version** ([DataTypes.md](https://github.com/buildingSMART/IDS/blob/development/Documentation/ImplementersDocumentation/DataTypes.md), [property-facet.md](https://github.com/buildingSMART/IDS/blob/development/Documentation/UserManual/property-facet.md)). It does **not** have to match the IFC pset template's exact type. `IFCPOSITIVELENGTHMEASURE` is valid for IFC2x3/IFC4/IFC4x3.

## Changes

- **Generate the allowlist from the standard.** New `scripts/generate-ids-datatypes.mjs` parses a committed copy of the official bS table (`scripts/ids-datatypes.md`) and emits per-version `simple-types-*.json` (lib + public). Now **269 / 323 / 359** datatypes for IFC2x3 / IFC4 / IFC4x3, all subtypes included, correctly version-scoped. Curated descriptions are preserved.
- **Subtype-aware recommendation, not an error.** `isPropertyDataTypeValid` now treats an exact match or same value-category (numeric/string/boolean/datetime, derived from the `xs:` base type) as valid. A genuinely different kind of value (e.g. a text type where a measure is expected) becomes a non-blocking **recommendation**, never a red error.
- **Version-aware datatype caches** (rebuild on IFC version change).
- **Fixed the PSD generator** to load the authoritative list first, so a future pset regeneration preserves subtypes.

## Verification (live app)

- `ConcreteCover` + `IfcPositiveLengthMeasure` → **Valid IDS** (false positive gone).
- `ConcreteCover` + `IFCLABEL` → **1 warning** (recommendation), message: *"Property "ConcreteCover" is usually defined as IFCLENGTHMEASURE in standard IFC property sets. You used "IFCLABEL" — a valid IDS datatype, but a different kind of value. Double-check this is intended."*
- `tsc --noEmit`: no new errors in changed files.

## Follow-ups (not in this PR)

- Transparency: show the validation engine + IDS/IFC schema versions, split the report into IDS-schema vs IFC-audit vs recommendations, CSV export (#49, #50).
- Regenerate `property-sets-*.json` from source so recommendation text shows the exact template subtype (the false positive is fixed regardless).

Closes #48
Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Property datatype validation now issues warnings instead of errors for recommendation-level mismatches.
  * Enhanced datatype validation to use version-aware compatibility checking alongside exact-match validation.
  * Generated comprehensive reference data documenting supported datatypes across multiple IFC schema versions.
  * Updated datatype normalization to prioritize authoritative schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->