### PR TITLE
Validation report: sections, transparency info button, CSV, no em-dashes (#49, #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A visual editor for creating Information Delivery Specifications (IDS) files wit
 ## Features
 
 - **Visual Graph Editor**: Drag-and-drop interface for creating IDS specifications
-- **Real-time Validation**: Automatic IDS validation in the browser via [`@ifc-lite/ids`](https://www.npmjs.com/package/@ifc-lite/ids) — no backend required
+- **Real-time Validation**: Automatic, fully in-browser validation, no backend required. IDS XML structure is parsed with [`@ifc-lite/ids`](https://www.npmjs.com/package/@ifc-lite/ids); the IFC schema audit (entities, property sets, datatypes) and recommendations are IDSedit's own checks. The official buildingSMART IDS Audit Tool is .NET and is not run here.
 - **Multiple Node Types**: Support for all IDS facet types (Entity, Property, Attribute, Classification, Material, PartOf, Restriction)
 - **Template System**: Pre-built specification templates
 - **Export/Import**: Save and load canvas configurations
@@ -33,10 +33,23 @@ A visual editor for creating Information Delivery Specifications (IDS) files wit
 
 ## IDS Validation
 
-Validation runs entirely in the browser using [`@ifc-lite/ids`](https://www.npmjs.com/package/@ifc-lite/ids):
+Validation runs entirely in the browser. There is no backend and the official
+buildingSMART IDS Audit Tool (which is .NET) is not used. The report is split
+into the same two layers that tool distinguishes, plus tool hints:
+
+- **IDS schema validation**: does the file conform to the IDS schema itself? IDS
+  XML structure is parsed with [`@ifc-lite/ids`](https://www.npmjs.com/package/@ifc-lite/ids).
+- **IFC schema audit**: are the referenced IFC entities, property sets and
+  datatypes valid for the selected IFC schema version? These are IDSedit's own
+  checks against the generated IFC schema.
+- **Recommendations**: non-binding hints (for example, a datatype that differs
+  from the standard property-set template). Not required by the IDS or IFC schema.
+
+Details:
 
 - **Automatic Validation**: Validates 2 seconds after you stop editing
 - **Manual Validation**: Click "Re-validate" on the canvas overlay or in the Inspector Panel
+- **Export**: Download the full report (severity, category, message, node) as CSV
 - **Status Indicators**:
   - 🟢 Valid IDS — no issues
   - 🟠 Warnings — non-blocking issues

--- a/app/docs/match-any-value/page.tsx
+++ b/app/docs/match-any-value/page.tsx
@@ -21,7 +21,7 @@ export default async function MatchAnyValuePage() {
             Match any value
           </h1>
           <p className="text-base md:text-lg text-slate-600 dark:text-slate-400">
-            Existence-only checks — leave the value field empty to match anything
+            Existence-only checks. Leave the value field empty to match anything
           </p>
         </div>
         <MarkdownContent content={content} />

--- a/app/docs/quick-start/page.tsx
+++ b/app/docs/quick-start/page.tsx
@@ -20,17 +20,17 @@ covers every shortcut and selection trick.
 const closing = `
 ## Where to next
 
-- [**Editor interactions**](/docs/using-the-editor) — every shortcut, multi-select, duplicate, copy/paste.
-- [**Match any value**](/docs/match-any-value) — leave the value field empty for existence-only checks.
-- [**Restrictions**](/docs/restrictions) — enumerations, regex patterns, numeric bounds, length limits.
-- [**Facet Reference**](/docs/facets/entity) — what each facet matches and how it serialises.
+- [**Editor interactions**](/docs/using-the-editor): every shortcut, multi-select, duplicate, copy/paste.
+- [**Match any value**](/docs/match-any-value): leave the value field empty for existence-only checks.
+- [**Restrictions**](/docs/restrictions): enumerations, regex patterns, numeric bounds, length limits.
+- [**Facet Reference**](/docs/facets/entity): what each facet matches and how it serialises.
 
 ## A handful of practical notes
 
 - IFC entity names are **upper case** in IDS XML: \`IFCWALL\`, not \`IfcWall\`. The editor enforces this.
-- Property data type is **optional** in IDS, but recommended — the editor will suggest the right one based on the property name.
+- Property data type is **optional** in IDS, but recommended. The editor will suggest the right one based on the property name.
 - The validation pill top-right of the canvas tells you the moment something is wrong; you don't need to export to find out.
-- The default canvas already contains a working \`Walls-FireRating\` spec — feel free to edit it as a starting point rather than build from scratch.
+- The default canvas already contains a working \`Walls-FireRating\` spec, so feel free to edit it as a starting point rather than build from scratch.
 `;
 
 export default async function QuickStartPage() {
@@ -60,7 +60,7 @@ export default async function QuickStartPage() {
 
         <ExampleBox
           title="Walkthrough: walls must have a Fire Rating"
-          description="One specification end-to-end — from blank canvas to exported XML."
+          description="One specification end to end, from blank canvas to exported XML."
         >
           <TabbedContent
             tabs={[
@@ -86,7 +86,7 @@ export default async function QuickStartPage() {
                       <div className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white flex items-center justify-center text-xs font-bold">3</div>
                       <div>
                         <strong>Add a Property, connect to Requirements</strong>
-                        <p className="text-slate-600 dark:text-slate-400">Click <em>Property</em>. Set <em>Property Set</em> to <code className="font-mono text-xs">Pset_WallCommon</code> and <em>Base Name</em> to <code className="font-mono text-xs">FireRating</code>. Leave the value empty — that's a wildcard meaning "must exist, any value passes". Wire it into <em>Requirements</em>.</p>
+                        <p className="text-slate-600 dark:text-slate-400">Click <em>Property</em>. Set <em>Property Set</em> to <code className="font-mono text-xs">Pset_WallCommon</code> and <em>Base Name</em> to <code className="font-mono text-xs">FireRating</code>. Leave the value empty, that&apos;s a wildcard meaning "must exist, any value passes". Wire it into <em>Requirements</em>.</p>
                       </div>
                     </div>
                     <div className="flex gap-3">

--- a/app/docs/using-the-editor/page.tsx
+++ b/app/docs/using-the-editor/page.tsx
@@ -21,7 +21,7 @@ export default async function UsingTheEditorPage() {
             Editor interactions
           </h1>
           <p className="text-base md:text-lg text-slate-600 dark:text-slate-400">
-            Add, connect, select, duplicate — every interaction the canvas supports
+            Add, connect, select, duplicate. Every interaction the canvas supports
           </p>
         </div>
         <MarkdownContent content={content} />

--- a/components/canvas-validation-overlay.tsx
+++ b/components/canvas-validation-overlay.tsx
@@ -17,6 +17,12 @@ import {
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import type { ValidationState } from "@/lib/use-ids-validation"
 import type { ValidationIssue, ValidationCategory } from "@/lib/ids-client-validation"
 import type { IFCVersion } from "@/lib/ifc-schema"
@@ -53,11 +59,6 @@ const CATEGORY_LABELS: Record<ValidationCategory, string> = {
   "ifc-audit": "IFC schema audit",
   recommendation: "Recommendations",
 }
-const CATEGORY_BLURB: Record<ValidationCategory, string> = {
-  "ids-schema": "Does the file conform to the IDS schema itself?",
-  "ifc-audit": "Are the referenced IFC types and datatypes valid for this schema?",
-  recommendation: "Non-binding hints. Not required by the IDS or IFC schema.",
-}
 
 function ifcVersionLabel(v?: IFCVersion): string {
   switch (v) {
@@ -68,7 +69,7 @@ function ifcVersionLabel(v?: IFCVersion): string {
     case "IFC2X3":
       return "IFC2X3"
     default:
-      return v || "—"
+      return "unknown"
   }
 }
 
@@ -89,12 +90,10 @@ function deriveStatus(
     field: i.field,
   }))
 
-  // Surface server / parser failures as errors — but only when they aren't
+  // Surface server / parser failures as errors, but only when they aren't
   // already itemized as client issues. On client-side failure, validationState
   // .error is just those same issues joined into a string, so unshifting it
-  // would duplicate every row (one aggregate copy + one per-issue copy). Only
-  // show it for non-itemized failures (an exception or parse error with no
-  // per-node issues to click). Parser/structure failures are IDS-schema issues.
+  // would duplicate every row. Parser / structure failures are IDS-schema issues.
   const hasClientErrors = clientIssues.some((i) => i.severity === "error")
   if (validationState.status === "error" && !hasClientErrors) {
     issues.unshift({
@@ -102,10 +101,7 @@ function deriveStatus(
       category: "ids-schema",
       message: validationState.error || "Validation failed",
     })
-  } else if (
-    validationState.result &&
-    validationState.result.status !== 0
-  ) {
+  } else if (validationState.result && validationState.result.status !== 0) {
     issues.unshift({
       severity: "error",
       category: "ids-schema",
@@ -166,7 +162,7 @@ const STATUS_META: Record<
     Icon: Sparkles,
   },
   loading: {
-    label: "Validating…",
+    label: "Validating",
     dotClass: "bg-blue-500",
     ringClass: "ring-blue-500/30",
     pillClass: "border-blue-500/40 bg-blue-500/10",
@@ -195,6 +191,13 @@ const STATUS_META: Record<
   },
 }
 
+// Count chip tint by the worst severity in a section.
+function chipClass(hasError: boolean, hasWarning: boolean): string {
+  if (hasError) return "bg-red-500/12 text-red-600 dark:text-red-400"
+  if (hasWarning) return "bg-amber-500/12 text-amber-600 dark:text-amber-400"
+  return "bg-foreground/8 text-muted-foreground"
+}
+
 export function CanvasValidationOverlay({
   validationState,
   isValidating,
@@ -217,23 +220,20 @@ export function CanvasValidationOverlay({
     ? formatRelativeTime(validationState.lastValidated)
     : null
 
-  // The panel is expandable whenever a validation has run, so the engine /
-  // schema-version transparency info (and the CSV export) are always reachable,
-  // even when the file is valid. See #49.
+  // The panel is expandable whenever a validation has run, so the engine info
+  // and CSV export stay reachable even when the file is valid. See #49.
   const hasRun = status !== "idle" && status !== "loading"
 
   const summary = (() => {
-    if (status === "loading") return "Validating…"
-    if (status === "idle" && !validationState.lastValidated)
-      return "Waiting for content"
+    if (status === "loading") return "Validating"
+    if (status === "idle" && !validationState.lastValidated) return "Waiting for content"
     if (status === "valid") return "IDS is valid"
     if (status === "warning")
       return `${warningCount} warning${warningCount === 1 ? "" : "s"}`
     if (status === "error") {
       const parts: string[] = []
       if (errorCount) parts.push(`${errorCount} error${errorCount === 1 ? "" : "s"}`)
-      if (warningCount)
-        parts.push(`${warningCount} warning${warningCount === 1 ? "" : "s"}`)
+      if (warningCount) parts.push(`${warningCount} warning${warningCount === 1 ? "" : "s"}`)
       return parts.join(" · ")
     }
     return meta.label
@@ -243,7 +243,7 @@ export function CanvasValidationOverlay({
     <Panel position="top-right" className="!m-3 !p-0">
       <div
         className={cn(
-          "min-w-[180px] max-w-[360px] rounded-lg border shadow-lg backdrop-blur",
+          "min-w-[200px] max-w-[360px] overflow-hidden rounded-xl border shadow-lg backdrop-blur",
           "transition-colors duration-200",
           meta.pillClass
         )}
@@ -253,9 +253,8 @@ export function CanvasValidationOverlay({
           onClick={() => hasRun && setExpanded((v) => !v)}
           disabled={!hasRun}
           className={cn(
-            "flex w-full items-center gap-2 px-2.5 py-1.5 rounded-lg",
-            "text-left",
-            hasRun && "hover:bg-foreground/5 cursor-pointer",
+            "flex w-full items-center gap-2.5 px-3 py-2 text-left",
+            hasRun && "cursor-pointer hover:bg-foreground/5",
             !hasRun && "cursor-default"
           )}
           aria-expanded={expanded}
@@ -264,7 +263,7 @@ export function CanvasValidationOverlay({
         >
           <span
             className={cn(
-              "relative inline-flex h-2.5 w-2.5 rounded-full ring-4",
+              "relative inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full ring-4",
               meta.dotClass,
               meta.ringClass
             )}
@@ -273,49 +272,53 @@ export function CanvasValidationOverlay({
               <span className="absolute inset-0 inline-flex h-full w-full animate-ping rounded-full bg-blue-500/70" />
             )}
           </span>
-          <div className="flex-1 min-w-0">
-            <div className="text-xs font-medium text-foreground leading-tight truncate">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs font-semibold leading-tight text-foreground">
               {meta.label}
             </div>
-            <div className="text-[10px] text-muted-foreground leading-tight truncate">
+            <div className="truncate text-[10px] leading-tight text-muted-foreground">
               {summary}
-              {lastValidatedLabel && status !== "loading" ? (
-                <> · {lastValidatedLabel}</>
-              ) : null}
+              {lastValidatedLabel && status !== "loading" ? <> · {lastValidatedLabel}</> : null}
             </div>
           </div>
           {hasRun ? (
             expanded ? (
-              <ChevronUp className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+              <ChevronUp className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
             ) : (
-              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+              <ChevronDown className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
             )
           ) : null}
         </button>
 
         {expanded && hasRun ? (
-          // Neutral surface for the list so red icons/accents read clearly
-          // instead of fighting the red-tinted header (red-on-red).
-          <div className="rounded-b-lg border-t border-border/60 bg-popover/95">
-            <div className="max-h-[300px] overflow-y-auto p-1.5">
+          // Neutral surface so severity accents read clearly against the tinted header.
+          <div className="border-t border-border/60 bg-popover/95">
+            <div className="max-h-[300px] overflow-y-auto px-1.5 py-1.5">
               {issues.length === 0 ? (
-                <div className="flex items-center gap-2 px-2 py-1.5 text-[11px] text-muted-foreground">
+                <div className="flex items-center gap-2 px-2 py-2 text-[11px] text-muted-foreground">
                   <CheckCircle2 className="h-3.5 w-3.5 flex-shrink-0 text-green-500" />
-                  No issues found.
+                  Nothing to fix. Everything checks out.
                 </div>
               ) : (
                 CATEGORY_ORDER.map((category) => {
                   const sectionIssues = issues.filter((i) => i.category === category)
                   if (sectionIssues.length === 0) return null
+                  const secHasError = sectionIssues.some((i) => i.severity === "error")
+                  const secHasWarning = sectionIssues.some((i) => i.severity === "warning")
                   return (
-                    <div key={category} className="mb-1.5 last:mb-0">
-                      <div className="px-2 pt-1 pb-0.5">
-                        <div className="text-[10px] font-semibold uppercase tracking-wide text-foreground/70">
+                    <div key={category} className="mb-2 last:mb-0.5">
+                      <div className="flex items-center gap-2 px-2 pb-1 pt-1">
+                        <span className="text-[10px] font-semibold uppercase tracking-wider text-foreground/55">
                           {CATEGORY_LABELS[category]}
-                        </div>
-                        <div className="text-[10px] leading-tight text-muted-foreground">
-                          {CATEGORY_BLURB[category]}
-                        </div>
+                        </span>
+                        <span
+                          className={cn(
+                            "ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-semibold tabular-nums",
+                            chipClass(secHasError, secHasWarning)
+                          )}
+                        >
+                          {sectionIssues.length}
+                        </span>
                       </div>
                       <ul className="space-y-0.5">
                         {sectionIssues.map((issue, idx) => {
@@ -323,7 +326,6 @@ export function CanvasValidationOverlay({
                           const isError = issue.severity === "error"
                           const body = (
                             <>
-                              {/* Severity rail — a calm accent rather than a flood of red */}
                               <span
                                 aria-hidden
                                 className={cn(
@@ -376,28 +378,14 @@ export function CanvasValidationOverlay({
               )}
             </div>
 
-            {/* Transparency: what actually ran. See #49. */}
-            <div className="border-t border-border/40 px-2.5 py-1.5">
-              <div className="flex items-start gap-1.5 text-[10px] leading-tight text-muted-foreground">
-                <Info className="mt-px h-3 w-3 flex-shrink-0" />
-                <span>
-                  Checked by IDSedit&apos;s built-in validation (IDS structure parsed with{" "}
-                  <span className="font-mono">@ifc-lite/ids</span>). The official buildingSMART
-                  IDS Audit Tool is .NET and does not run in the browser, so it is not used here.
-                  <br />
-                  IDS schema 1.0 · IFC {ifcVersionLabel(ifcVersion)}
-                </span>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-1.5 border-t border-border/40 p-1.5">
+            <div className="flex items-center gap-1 border-t border-border/40 p-1.5">
               {onValidateNow ? (
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={onValidateNow}
                   disabled={isValidating || isDisabled}
-                  className="h-6 flex-1 justify-center gap-1.5 text-[11px]"
+                  className="h-7 flex-1 justify-center gap-1.5 text-[11px]"
                 >
                   {isValidating ? (
                     <Loader2 className="h-3 w-3 animate-spin" />
@@ -412,12 +400,53 @@ export function CanvasValidationOverlay({
                 size="sm"
                 onClick={() => downloadCsv(issues)}
                 disabled={issues.length === 0}
-                className="h-6 flex-1 justify-center gap-1.5 text-[11px]"
-                title="Export the validation report as CSV"
+                className="h-7 flex-1 justify-center gap-1.5 text-[11px]"
+                title="Export the report as CSV"
               >
                 <Download className="h-3 w-3" />
                 Export CSV
               </Button>
+
+              {/* Transparency: what actually ran. Hover for details. See #49. */}
+              <TooltipProvider delayDuration={150}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="How this file is checked"
+                      className="inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    >
+                      <Info className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" align="end" className="max-w-[260px] p-0">
+                    <div className="space-y-1.5 p-2.5 text-[11px] leading-snug">
+                      <p className="font-semibold text-foreground">How this file is checked</p>
+                      <ul className="space-y-1 text-muted-foreground">
+                        <li>
+                          <span className="font-medium text-foreground/80">IDS schema:</span>{" "}
+                          structure parsed with <span className="font-mono">@ifc-lite/ids</span>.
+                        </li>
+                        <li>
+                          <span className="font-medium text-foreground/80">IFC schema audit:</span>{" "}
+                          IDSedit&apos;s own checks against the IFC schema.
+                        </li>
+                        <li>
+                          <span className="font-medium text-foreground/80">Recommendations:</span>{" "}
+                          hints only, not required by the standard.
+                        </li>
+                      </ul>
+                      <p className="text-muted-foreground">
+                        The official buildingSMART IDS Audit Tool is .NET, so it does not run in
+                        the browser and is not used here.
+                      </p>
+                      <p className="border-t border-border/60 pt-1.5 font-mono text-[10px] text-muted-foreground">
+                        IDS schema 1.0 · IFC {ifcVersionLabel(ifcVersion)}
+                      </p>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
           </div>
         ) : null}

--- a/components/canvas-validation-overlay.tsx
+++ b/components/canvas-validation-overlay.tsx
@@ -12,16 +12,20 @@ import {
   RefreshCw,
   Sparkles,
   Locate,
+  Download,
+  Info,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import type { ValidationState } from "@/lib/use-ids-validation"
-import type { ValidationIssue } from "@/lib/ids-client-validation"
+import type { ValidationIssue, ValidationCategory } from "@/lib/ids-client-validation"
+import type { IFCVersion } from "@/lib/ifc-schema"
 
 interface CanvasValidationOverlayProps {
   validationState: ValidationState
   isValidating: boolean
   isDisabled: boolean
+  ifcVersion?: IFCVersion
   onValidateNow?: () => void
   /** Jump to + select the node a validation issue points at. */
   onIssueSelect?: (nodeId: string, field?: string) => void
@@ -32,11 +36,40 @@ type OverlayStatus = "idle" | "loading" | "valid" | "warning" | "error"
 interface DisplayIssue {
   severity: "error" | "warning"
   message: string
+  category: ValidationCategory
   detail?: string
   // Carried through from the client-side ValidationIssue so each row can link
   // back to its node. Absent for parser/structure errors that aren't mapped.
   nodeId?: string
   field?: string
+}
+
+// The report is split the same way the official buildingSMART IDS Audit Tool
+// splits it: IDS-schema conformance vs IFC-schema conformance, plus our own
+// non-binding hints. See #50.
+const CATEGORY_ORDER: ValidationCategory[] = ["ids-schema", "ifc-audit", "recommendation"]
+const CATEGORY_LABELS: Record<ValidationCategory, string> = {
+  "ids-schema": "IDS schema validation",
+  "ifc-audit": "IFC schema audit",
+  recommendation: "Recommendations",
+}
+const CATEGORY_BLURB: Record<ValidationCategory, string> = {
+  "ids-schema": "Does the file conform to the IDS schema itself?",
+  "ifc-audit": "Are the referenced IFC types and datatypes valid for this schema?",
+  recommendation: "Non-binding hints. Not required by the IDS or IFC schema.",
+}
+
+function ifcVersionLabel(v?: IFCVersion): string {
+  switch (v) {
+    case "IFC4X3_ADD2":
+      return "IFC4X3 ADD2"
+    case "IFC4":
+      return "IFC4"
+    case "IFC2X3":
+      return "IFC2X3"
+    default:
+      return v || "—"
+  }
 }
 
 function deriveStatus(
@@ -51,6 +84,7 @@ function deriveStatus(
   const issues: DisplayIssue[] = clientIssues.map((i) => ({
     severity: i.severity,
     message: i.message,
+    category: i.category,
     nodeId: i.nodeId,
     field: i.field,
   }))
@@ -60,11 +94,12 @@ function deriveStatus(
   // .error is just those same issues joined into a string, so unshifting it
   // would duplicate every row (one aggregate copy + one per-issue copy). Only
   // show it for non-itemized failures (an exception or parse error with no
-  // per-node issues to click).
+  // per-node issues to click). Parser/structure failures are IDS-schema issues.
   const hasClientErrors = clientIssues.some((i) => i.severity === "error")
   if (validationState.status === "error" && !hasClientErrors) {
     issues.unshift({
       severity: "error",
+      category: "ids-schema",
       message: validationState.error || "Validation failed",
     })
   } else if (
@@ -73,6 +108,7 @@ function deriveStatus(
   ) {
     issues.unshift({
       severity: "error",
+      category: "ids-schema",
       message: validationState.result.message,
       detail: validationState.result.details,
     })
@@ -87,6 +123,29 @@ function deriveStatus(
   if (hasErrors) return { status: "error", issues }
   if (hasWarnings) return { status: "warning", issues }
   return { status: "valid", issues }
+}
+
+function toCsv(issues: DisplayIssue[]): string {
+  const esc = (v: string) => `"${(v ?? "").replace(/"/g, '""')}"`
+  const header = ["Severity", "Category", "Message", "Node", "Field"]
+  const rows = issues.map((i) =>
+    [i.severity, CATEGORY_LABELS[i.category], i.message, i.nodeId || "", i.field || ""]
+      .map((c) => esc(String(c)))
+      .join(",")
+  )
+  return [header.map(esc).join(","), ...rows].join("\r\n")
+}
+
+function downloadCsv(issues: DisplayIssue[]) {
+  const blob = new Blob([toCsv(issues)], { type: "text/csv;charset=utf-8;" })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = "ids-validation-report.csv"
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
 }
 
 const STATUS_META: Record<
@@ -140,6 +199,7 @@ export function CanvasValidationOverlay({
   validationState,
   isValidating,
   isDisabled,
+  ifcVersion,
   onValidateNow,
   onIssueSelect,
 }: CanvasValidationOverlayProps) {
@@ -156,6 +216,11 @@ export function CanvasValidationOverlay({
   const lastValidatedLabel = validationState.lastValidated
     ? formatRelativeTime(validationState.lastValidated)
     : null
+
+  // The panel is expandable whenever a validation has run, so the engine /
+  // schema-version transparency info (and the CSV export) are always reachable,
+  // even when the file is valid. See #49.
+  const hasRun = status !== "idle" && status !== "loading"
 
   const summary = (() => {
     if (status === "loading") return "Validating…"
@@ -178,20 +243,20 @@ export function CanvasValidationOverlay({
     <Panel position="top-right" className="!m-3 !p-0">
       <div
         className={cn(
-          "min-w-[180px] max-w-[340px] rounded-lg border shadow-lg backdrop-blur",
+          "min-w-[180px] max-w-[360px] rounded-lg border shadow-lg backdrop-blur",
           "transition-colors duration-200",
           meta.pillClass
         )}
       >
         <button
           type="button"
-          onClick={() => issues.length > 0 && setExpanded((v) => !v)}
-          disabled={issues.length === 0}
+          onClick={() => hasRun && setExpanded((v) => !v)}
+          disabled={!hasRun}
           className={cn(
             "flex w-full items-center gap-2 px-2.5 py-1.5 rounded-lg",
             "text-left",
-            issues.length > 0 && "hover:bg-foreground/5 cursor-pointer",
-            issues.length === 0 && "cursor-default"
+            hasRun && "hover:bg-foreground/5 cursor-pointer",
+            !hasRun && "cursor-default"
           )}
           aria-expanded={expanded}
           aria-label={`IDS validation: ${summary}`}
@@ -219,7 +284,7 @@ export function CanvasValidationOverlay({
               ) : null}
             </div>
           </div>
-          {issues.length > 0 ? (
+          {hasRun ? (
             expanded ? (
               <ChevronUp className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
             ) : (
@@ -228,71 +293,111 @@ export function CanvasValidationOverlay({
           ) : null}
         </button>
 
-        {expanded && issues.length > 0 ? (
+        {expanded && hasRun ? (
           // Neutral surface for the list so red icons/accents read clearly
           // instead of fighting the red-tinted header (red-on-red).
           <div className="rounded-b-lg border-t border-border/60 bg-popover/95">
-            <ul className="max-h-[280px] space-y-0.5 overflow-y-auto p-1.5">
-              {issues.map((issue, idx) => {
-                const linkable = Boolean(issue.nodeId && onIssueSelect)
-                const isError = issue.severity === "error"
-                const body = (
-                  <>
-                    {/* Severity rail — a calm accent rather than a flood of red */}
-                    <span
-                      aria-hidden
-                      className={cn(
-                        "mt-0.5 w-0.5 self-stretch rounded-full",
-                        isError ? "bg-red-500/70" : "bg-amber-500/70"
-                      )}
-                    />
-                    {isError ? (
-                      <XCircle className="mt-px h-3.5 w-3.5 flex-shrink-0 text-red-500" />
-                    ) : (
-                      <AlertCircle className="mt-px h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <div className="text-foreground/90">{issue.message}</div>
-                      {issue.detail ? (
-                        <div className="mt-0.5 break-words font-mono text-[10px] text-muted-foreground">
-                          {issue.detail}
+            <div className="max-h-[300px] overflow-y-auto p-1.5">
+              {issues.length === 0 ? (
+                <div className="flex items-center gap-2 px-2 py-1.5 text-[11px] text-muted-foreground">
+                  <CheckCircle2 className="h-3.5 w-3.5 flex-shrink-0 text-green-500" />
+                  No issues found.
+                </div>
+              ) : (
+                CATEGORY_ORDER.map((category) => {
+                  const sectionIssues = issues.filter((i) => i.category === category)
+                  if (sectionIssues.length === 0) return null
+                  return (
+                    <div key={category} className="mb-1.5 last:mb-0">
+                      <div className="px-2 pt-1 pb-0.5">
+                        <div className="text-[10px] font-semibold uppercase tracking-wide text-foreground/70">
+                          {CATEGORY_LABELS[category]}
                         </div>
-                      ) : null}
-                    </div>
-                    {linkable ? (
-                      <Locate className="mt-px h-3.5 w-3.5 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
-                    ) : null}
-                  </>
-                )
-                return (
-                  <li key={idx}>
-                    {linkable ? (
-                      <button
-                        type="button"
-                        onClick={() => onIssueSelect!(issue.nodeId!, issue.field)}
-                        title="Go to node"
-                        aria-label={`Go to node: ${issue.message}`}
-                        className="group flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-[11px] leading-snug transition-colors hover:bg-foreground/[0.06]"
-                      >
-                        {body}
-                      </button>
-                    ) : (
-                      <div className="flex items-start gap-2 rounded-md px-2 py-1.5 text-[11px] leading-snug">
-                        {body}
+                        <div className="text-[10px] leading-tight text-muted-foreground">
+                          {CATEGORY_BLURB[category]}
+                        </div>
                       </div>
-                    )}
-                  </li>
-                )
-              })}
-            </ul>
-            {onValidateNow ? (
-              <div className="border-t border-border/40 p-1.5">
+                      <ul className="space-y-0.5">
+                        {sectionIssues.map((issue, idx) => {
+                          const linkable = Boolean(issue.nodeId && onIssueSelect)
+                          const isError = issue.severity === "error"
+                          const body = (
+                            <>
+                              {/* Severity rail — a calm accent rather than a flood of red */}
+                              <span
+                                aria-hidden
+                                className={cn(
+                                  "mt-0.5 w-0.5 self-stretch rounded-full",
+                                  isError ? "bg-red-500/70" : "bg-amber-500/70"
+                                )}
+                              />
+                              {isError ? (
+                                <XCircle className="mt-px h-3.5 w-3.5 flex-shrink-0 text-red-500" />
+                              ) : (
+                                <AlertCircle className="mt-px h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
+                              )}
+                              <div className="min-w-0 flex-1">
+                                <div className="text-foreground/90">{issue.message}</div>
+                                {issue.detail ? (
+                                  <div className="mt-0.5 break-words font-mono text-[10px] text-muted-foreground">
+                                    {issue.detail}
+                                  </div>
+                                ) : null}
+                              </div>
+                              {linkable ? (
+                                <Locate className="mt-px h-3.5 w-3.5 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+                              ) : null}
+                            </>
+                          )
+                          return (
+                            <li key={idx}>
+                              {linkable ? (
+                                <button
+                                  type="button"
+                                  onClick={() => onIssueSelect!(issue.nodeId!, issue.field)}
+                                  title="Go to node"
+                                  aria-label={`Go to node: ${issue.message}`}
+                                  className="group flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-[11px] leading-snug transition-colors hover:bg-foreground/[0.06]"
+                                >
+                                  {body}
+                                </button>
+                              ) : (
+                                <div className="flex items-start gap-2 rounded-md px-2 py-1.5 text-[11px] leading-snug">
+                                  {body}
+                                </div>
+                              )}
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    </div>
+                  )
+                })
+              )}
+            </div>
+
+            {/* Transparency: what actually ran. See #49. */}
+            <div className="border-t border-border/40 px-2.5 py-1.5">
+              <div className="flex items-start gap-1.5 text-[10px] leading-tight text-muted-foreground">
+                <Info className="mt-px h-3 w-3 flex-shrink-0" />
+                <span>
+                  Checked by IDSedit&apos;s built-in validation (IDS structure parsed with{" "}
+                  <span className="font-mono">@ifc-lite/ids</span>). The official buildingSMART
+                  IDS Audit Tool is .NET and does not run in the browser, so it is not used here.
+                  <br />
+                  IDS schema 1.0 · IFC {ifcVersionLabel(ifcVersion)}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-1.5 border-t border-border/40 p-1.5">
+              {onValidateNow ? (
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={onValidateNow}
                   disabled={isValidating || isDisabled}
-                  className="h-6 w-full justify-center gap-1.5 text-[11px]"
+                  className="h-6 flex-1 justify-center gap-1.5 text-[11px]"
                 >
                   {isValidating ? (
                     <Loader2 className="h-3 w-3 animate-spin" />
@@ -301,8 +406,19 @@ export function CanvasValidationOverlay({
                   )}
                   Re-validate
                 </Button>
-              </div>
-            ) : null}
+              ) : null}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => downloadCsv(issues)}
+                disabled={issues.length === 0}
+                className="h-6 flex-1 justify-center gap-1.5 text-[11px]"
+                title="Export the validation report as CSV"
+              >
+                <Download className="h-3 w-3" />
+                Export CSV
+              </Button>
+            </div>
           </div>
         ) : null}
       </div>

--- a/components/graph-canvas.tsx
+++ b/components/graph-canvas.tsx
@@ -16,6 +16,7 @@ import { RestrictionNode } from "./nodes/restriction-node"
 import { FACET_COLORS } from "@/lib/facet-colors"
 import { CanvasValidationOverlay } from "./canvas-validation-overlay"
 import type { ValidationState } from "@/lib/use-ids-validation"
+import type { IFCVersion } from "@/lib/ifc-schema"
 
 interface GraphCanvasProps {
   nodes: GraphNode[]
@@ -52,6 +53,7 @@ interface GraphCanvasProps {
   isValidating?: boolean
   isValidationDisabled?: boolean
   onValidateNow?: () => void
+  ifcVersion?: IFCVersion
 }
 
 const nodeTypes = {
@@ -66,7 +68,7 @@ const nodeTypes = {
 }
 
 
-export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes, onAddNode, pendingSelectionIds, onPendingSelectionConsumed, pendingFocusNodeId, onPendingFocusConsumed, onIssueSelect, validationState, isValidating = false, isValidationDisabled = false, onValidateNow }: GraphCanvasProps) {
+export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMove, onNodeDragStart, onConnect, onNodesDelete, onEdgesDelete, onDuplicateNodes, onAddNode, pendingSelectionIds, onPendingSelectionConsumed, pendingFocusNodeId, onPendingFocusConsumed, onIssueSelect, validationState, isValidating = false, isValidationDisabled = false, onValidateNow, ifcVersion }: GraphCanvasProps) {
   const [showMinimap, setShowMinimap] = useState(true)
   const [focusedSpecTargets, setFocusedSpecTargets] = useState<Record<string, 'applicability' | 'requirements'>>({})
   const [focusedFacetColor, setFocusedFacetColor] = useState<string | null>(null)
@@ -572,6 +574,7 @@ export function GraphCanvas({ nodes, edges, selectedNode, onNodeSelect, onNodeMo
             validationState={validationState}
             isValidating={isValidating}
             isDisabled={isValidationDisabled}
+            ifcVersion={ifcVersion}
             onValidateNow={onValidateNow}
             onIssueSelect={onIssueSelect}
           />

--- a/components/inspector-panel.tsx
+++ b/components/inspector-panel.tsx
@@ -191,7 +191,7 @@ function ConvertToRestrictionHint({
   return (
     <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-accent/40 bg-accent/5 px-2 py-1.5">
       <span className="text-[11px] text-muted-foreground">
-        {parsed.length} values detected — convert to a Restriction node?
+        {parsed.length} values detected. Convert to a Restriction node?
       </span>
       <Button
         type="button"
@@ -1067,11 +1067,11 @@ function PropertyFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           id="value"
           value={data.value || ""}
           onChange={(e) => onChange("value", e.target.value)}
-          placeholder={getPlaceholderForDataType(data.dataType) || "Any value — leave empty to match any"}
+          placeholder={getPlaceholderForDataType(data.dataType) || "Any value, or leave empty to match any"}
           className="bg-input border-border text-foreground"
         />
         <p className="text-[11px] text-muted-foreground">
-          Leave empty to match any value. For multiple allowed values, type <code className="font-mono">[a, b, c]</code> — convertible to a Restriction node below.
+          Leave empty to match any value. For multiple allowed values, type <code className="font-mono">[a, b, c]</code>, convertible to a Restriction node below.
         </p>
         {onConvertValueToRestriction && (
           <ConvertToRestrictionHint
@@ -1239,7 +1239,7 @@ function AttributeFields({ node, onChange, ifcVersion, nodes, edges, onConvertVa
           id="attribute-value"
           value={data.value || ""}
           onChange={(e) => onChange("value", e.target.value)}
-          placeholder="Any value — or e.g. Fire Door / [Fire Door, Exit Door]"
+          placeholder="Any value, or e.g. Fire Door / [Fire Door, Exit Door]"
           className="bg-input border-border text-foreground"
         />
         <p className="text-[11px] text-muted-foreground">
@@ -1292,11 +1292,11 @@ function ClassificationFields({ node, onChange, ifcVersion, nodes, edges, onConv
           id="classification-system"
           value={data.system || ""}
           onChange={(e) => onChange("system", e.target.value)}
-          placeholder="Any system — or e.g. Uniclass 2015, OmniClass, ETIM"
+          placeholder="Any system, or e.g. Uniclass 2015, OmniClass, ETIM"
           className="bg-input border-border text-foreground font-mono"
         />
         <p className="text-[11px] text-muted-foreground">
-          Leave empty to match any classification (any system). Type any string — the IDS schema doesn't constrain the system name.
+          Leave empty to match any classification (any system). Type any string, the IDS schema doesn&apos;t constrain the system name.
         </p>
       </div>
       <div className="space-y-2">
@@ -1307,7 +1307,7 @@ function ClassificationFields({ node, onChange, ifcVersion, nodes, edges, onConv
           id="classification-value"
           value={data.value || ""}
           onChange={(e) => onChange("value", e.target.value)}
-          placeholder="Any code — or e.g. Pr_20_70_05_05 / [Pr_20_70_05_05, Pr_20_70_05_06]"
+          placeholder="Any code, or e.g. Pr_20_70_05_05 / [Pr_20_70_05_05, Pr_20_70_05_06]"
           className="bg-input border-border text-foreground font-mono"
         />
         <p className="text-[11px] text-muted-foreground">
@@ -1372,7 +1372,7 @@ function MaterialFields({ node, onChange, ifcVersion, nodes, edges, onConvertVal
           id="material-value"
           value={data.value || ""}
           onChange={(e) => onChange("value", e.target.value)}
-          placeholder="Any material — or e.g. concrete, oak, rebar steel"
+          placeholder="Any material, or e.g. concrete, oak, rebar steel"
           className="bg-input border-border text-foreground font-mono"
         />
         <p className="text-[11px] text-muted-foreground">

--- a/components/schema-switcher.tsx
+++ b/components/schema-switcher.tsx
@@ -41,13 +41,13 @@ export function SchemaSwitcher({ version, onVersionChange }: SchemaSwitcherProps
               accepts these three values:
             </p>
             <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-              <li><span className="font-mono">IFC2X3</span> — legacy</li>
-              <li><span className="font-mono">IFC4</span> — widely supported</li>
-              <li><span className="font-mono">IFC4X3_ADD2</span> — latest IDS-recognized</li>
+              <li><span className="font-mono">IFC2X3</span>, legacy</li>
+              <li><span className="font-mono">IFC4</span>, widely supported</li>
+              <li><span className="font-mono">IFC4X3_ADD2</span>, latest IDS-recognized</li>
             </ul>
             <p className="text-muted-foreground">
               Newer IFC releases (e.g. IFC4.4) aren&apos;t in the IDS schema yet, so
-              they&apos;re intentionally not listed — picking one would fail XSD
+              they&apos;re intentionally not listed, since picking one would fail XSD
               validation downstream.
             </p>
             <p className="text-muted-foreground">

--- a/components/specification-editor.tsx
+++ b/components/specification-editor.tsx
@@ -922,6 +922,7 @@ export function SpecificationEditor() {
                 isValidating={isValidating}
                 isValidationDisabled={isValidationDisabled}
                 onValidateNow={validateNow}
+                ifcVersion={ifcVersion}
               />
             </Panel>
             <CustomPanelResizeHandle />

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -15,15 +15,19 @@ const TooltipContent = React.forwardRef<
     React.ElementRef<typeof TooltipPrimitive.Content>,
     React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-    <TooltipPrimitive.Content
-        ref={ref}
-        sideOffset={sideOffset}
-        className={cn(
-            "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-            className
-        )}
-        {...props}
-    />
+    // Portal to <body> so the tooltip escapes ancestors that clip it
+    // (e.g. overflow-hidden / backdrop-blur containers like the canvas overlay).
+    <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+            ref={ref}
+            sideOffset={sideOffset}
+            className={cn(
+                "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+                className
+            )}
+            {...props}
+        />
+    </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 

--- a/lib/ids-client-validation.ts
+++ b/lib/ids-client-validation.ts
@@ -4,11 +4,11 @@ import { validateDataType, isPropertyDataTypeValid, getAllSimpleTypes, ensurePro
 // Which kind of check produced an issue, so the report can keep them separate
 // (see #50). The official buildingSMART IDS Audit Tool makes the same split
 // between IDS-XSD conformance and IFC-schema conformance.
-//   'ids-schema'     — does the file conform to the IDS schema itself
-//                      (required facets/fields, structure)?
-//   'ifc-audit'      — are the referenced IFC types/datatypes valid for the
-//                      selected IFC schema version?
-//   'recommendation' — non-binding tool hints (not required by either standard).
+//   'ids-schema':     does the file conform to the IDS schema itself
+//                     (required facets/fields, structure)?
+//   'ifc-audit':      are the referenced IFC types/datatypes valid for the
+//                     selected IFC schema version?
+//   'recommendation': non-binding tool hints (not required by either standard).
 export type ValidationCategory = 'ids-schema' | 'ifc-audit' | 'recommendation'
 
 export interface ValidationIssue {
@@ -35,7 +35,7 @@ export interface ClientValidationResult {
  * The ifcVersion parameter is required for property data-type semantic
  * validation (e.g. LoadBearing must be IFCBOOLEAN, not IFCDATE).
  * The function ensures the property-to-datatype cache is populated before
- * checking, so it is fully self-contained — no external initialisation needed.
+ * checking, so it is fully self-contained, with no external initialisation needed.
  */
 export async function validateGraphClientSide(
     nodes: GraphNode[],
@@ -97,7 +97,7 @@ export async function validateGraphClientSide(
                 issues.push({
                     severity: 'warning',
                     category: 'recommendation',
-                    message: `Property "${data.baseName}" is usually defined as ${validation.expectedTypes.join(' or ')} in standard IFC property sets. You used "${data.dataType}" — a valid IDS datatype, but a different kind of value. Double-check this is intended.`,
+                    message: `Property "${data.baseName}" is usually defined as ${validation.expectedTypes.join(' or ')} in standard IFC property sets. You used "${data.dataType}", which is a valid IDS datatype but a different kind of value, so double check that is what you want.`,
                     nodeId: node.id,
                     nodeType: 'property',
                     field: 'dataType',
@@ -145,7 +145,7 @@ export async function validateGraphClientSide(
         }
     }
 
-    // Note: an empty classification system is intentional — it means
+    // Note: an empty classification system is intentional, it means
     // "match any classification (any system)" and is emitted as an XSD-valid
     // pattern restriction `.+` by the XML converter. No warning needed.
 

--- a/lib/ids-client-validation.ts
+++ b/lib/ids-client-validation.ts
@@ -1,9 +1,20 @@
 import type { GraphNode, GraphEdge } from './graph-types'
 import { validateDataType, isPropertyDataTypeValid, getAllSimpleTypes, ensurePropertyDataTypeCache, type IFCVersion } from './ifc-schema'
 
+// Which kind of check produced an issue, so the report can keep them separate
+// (see #50). The official buildingSMART IDS Audit Tool makes the same split
+// between IDS-XSD conformance and IFC-schema conformance.
+//   'ids-schema'     — does the file conform to the IDS schema itself
+//                      (required facets/fields, structure)?
+//   'ifc-audit'      — are the referenced IFC types/datatypes valid for the
+//                      selected IFC schema version?
+//   'recommendation' — non-binding tool hints (not required by either standard).
+export type ValidationCategory = 'ids-schema' | 'ifc-audit' | 'recommendation'
+
 export interface ValidationIssue {
     severity: 'error' | 'warning'
     message: string
+    category: ValidationCategory
     nodeId?: string
     nodeType?: string
     // The specific data field this issue is about (e.g. 'dataType', 'baseName').
@@ -38,6 +49,7 @@ export async function validateGraphClientSide(
     if (specNodes.length === 0) {
         issues.push({
             severity: 'error',
+            category: 'ids-schema',
             message: 'At least one specification node is required',
         })
         return { isValid: false, issues }
@@ -64,6 +76,7 @@ export async function validateGraphClientSide(
             if (!isValidDataType) {
                 issues.push({
                     severity: 'error',
+                    category: 'ifc-audit',
                     message: `Invalid IFC data type "${data.dataType}" in property "${data.baseName || 'unnamed'}"`,
                     nodeId: node.id,
                     nodeType: 'property',
@@ -83,6 +96,7 @@ export async function validateGraphClientSide(
             if (!validation.valid && validation.expectedTypes) {
                 issues.push({
                     severity: 'warning',
+                    category: 'recommendation',
                     message: `Property "${data.baseName}" is usually defined as ${validation.expectedTypes.join(' or ')} in standard IFC property sets. You used "${data.dataType}" — a valid IDS datatype, but a different kind of value. Double-check this is intended.`,
                     nodeId: node.id,
                     nodeType: 'property',
@@ -91,10 +105,11 @@ export async function validateGraphClientSide(
             }
         }
 
-        // Check for required fields
+        // Check for required fields (a property facet requires both per the IDS schema)
         if (!data.propertySet) {
             issues.push({
                 severity: 'warning',
+                category: 'ids-schema',
                 message: `Property node is missing propertySet`,
                 nodeId: node.id,
                 nodeType: 'property',
@@ -105,6 +120,7 @@ export async function validateGraphClientSide(
         if (!data.baseName) {
             issues.push({
                 severity: 'warning',
+                category: 'ids-schema',
                 message: `Property node is missing baseName`,
                 nodeId: node.id,
                 nodeType: 'property',
@@ -120,6 +136,7 @@ export async function validateGraphClientSide(
         if (!data.name) {
             issues.push({
                 severity: 'error',
+                category: 'ids-schema',
                 message: 'Entity node is missing name',
                 nodeId: node.id,
                 nodeType: 'entity',
@@ -149,6 +166,7 @@ export async function validateGraphClientSide(
             if (!hasEntity) {
                 issues.push({
                     severity: 'warning',
+                    category: 'recommendation',
                     message: `Specification "${(specNode.data as any).name || 'unnamed'}" applicability should include at least one entity`,
                     nodeId: specNode.id,
                     nodeType: 'spec',

--- a/lib/ifc-schema.ts
+++ b/lib/ifc-schema.ts
@@ -240,8 +240,8 @@ export async function validateDataTypeAsync(dataType: string, version: IFCVersio
 // Coarse value categories. Two datatypes in the SAME category are considered
 // interchangeable enough that swapping one for the other (e.g. a measure
 // subtype like IFCPOSITIVELENGTHMEASURE for its base IFCLENGTHMEASURE) is never
-// flagged. Per the IDS spec, ANY valid datatype is acceptable for a property —
-// the standard IFC pset template type is only a recommendation — so we only hint
+// flagged. Per the IDS spec, ANY valid datatype is acceptable for a property:
+// the standard IFC pset template type is only a recommendation, so we only hint
 // when the chosen datatype is a fundamentally different *kind* of value.
 export type DataTypeCategory =
   | 'numeric'
@@ -558,7 +558,7 @@ export async function getExpectedDataTypesForPropertyAsync(propertyName: string,
  *
  * IMPORTANT (issues #48 / #52): per the IDS specification, a property `dataType`
  * is OPTIONAL and, when present, only needs to be a valid datatype for the
- * schema version — it does NOT have to match the IFC pset template's exact type.
+ * schema version. It does NOT have to match the IFC pset template's exact type.
  * So this is a *recommendation* helper, not an IDS rule:
  *   - exact match, or same value category (e.g. IFCPOSITIVELENGTHMEASURE vs its
  *     base IFCLENGTHMEASURE) → `valid: true`, no hint.


### PR DESCRIPTION
Reopens the work from #54 against `main` (that PR auto-closed when its stacked base branch was deleted by the #53 merge).

## What

Transparency and clarity for the validation report (the public Bane NOR thread highlighted both).

- **Sectioned report (#50).** Every finding is tagged `ids-schema` | `ifc-audit` | `recommendation` and grouped under labelled sections with per-section count chips. This mirrors the split the official buildingSMART IDS Audit Tool makes between IDS-XSD conformance and IFC-schema conformance, and keeps non-binding hints separate.
- **Transparency (#49).** An info button (hover tooltip) on the report states what ran: built-in checks, IDS structure parsed with `@ifc-lite/ids`, that the official buildingSMART IDS Audit Tool is .NET and is not run in-browser, plus the IDS schema version and the IFC schema being checked against.
- **CSV export** of the full report (severity, category, message, node, field).
- **Redesign**: cleaner sections, calmer rows, refined header.
- **Tooltip portal fix**: the shared `Tooltip` now portals to `<body>` so it is not clipped by the overlay's `overflow-hidden` / `backdrop-blur` container.
- **No em-dashes** in user-facing copy (validation message, schema switcher, inspector placeholders, docs), reworded in a plainer voice.
- README updated to describe the three report layers and CSV export.

## Verified (live app)

Report renders three labelled sections with count chips; the info tooltip opens on hover with the engine + `IDS schema 1.0 · IFC IFC4X3 ADD2` line; CSV export present. `tsc --noEmit` shows no new errors in changed files.

Closes #49
Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)