### PR TITLE
fix: accept IFC reference datatypes so valid IDS files stop false-erroring (#58)

### DIFF
--- a/lib/generated/ifc-schema/simple-types-ifc4.json
+++ b/lib/generated/ifc-schema/simple-types-ifc4.json
@@ -205,6 +205,12 @@
     "description": "Enumeration value"
   },
   {
+    "name": "IFCCOMPLEXNUMBER",
+    "baseType": "",
+    "description": "Complex number (reference value)",
+    "category": "reference"
+  },
+  {
     "name": "IFCCOMPLEXPROPERTYTEMPLATETYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -545,6 +551,12 @@
     "description": "Enumeration value"
   },
   {
+    "name": "IFCEXTERNALREFERENCE",
+    "baseType": "",
+    "description": "Reference to an external source (classification, document or library)",
+    "category": "reference"
+  },
+  {
     "name": "IFCEXTERNALSPATIALELEMENTTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -850,6 +862,12 @@
     "description": "Measure value (decimal)"
   },
   {
+    "name": "IFCMATERIALDEFINITION",
+    "baseType": "",
+    "description": "Reference to a material definition",
+    "category": "reference"
+  },
+  {
     "name": "IFCMECHANICALFASTENERTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -978,6 +996,12 @@
     "name": "IFCPERMITTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERSON",
+    "baseType": "",
+    "description": "Reference to a person",
+    "category": "reference"
   },
   {
     "name": "IFCPHMEASURE",
@@ -1470,6 +1494,12 @@
     "description": "Time measurement"
   },
   {
+    "name": "IFCTIMESERIES",
+    "baseType": "",
+    "description": "Reference to a time series",
+    "category": "reference"
+  },
+  {
     "name": "IFCTIMESERIESDATATYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -1518,6 +1548,12 @@
     "name": "IFCURIREFERENCE",
     "baseType": "xs:string",
     "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCVALUE",
+    "baseType": "",
+    "description": "Any IFC value (measure, simple or derived value)",
+    "category": "reference"
   },
   {
     "name": "IFCVALVETYPEENUM",

--- a/lib/generated/ifc-schema/simple-types-ifc4x3_add2.json
+++ b/lib/generated/ifc-schema/simple-types-ifc4x3_add2.json
@@ -255,6 +255,12 @@
     "description": "Enumeration value"
   },
   {
+    "name": "IFCCOMPLEXNUMBER",
+    "baseType": "",
+    "description": "Complex number (reference value)",
+    "category": "reference"
+  },
+  {
     "name": "IFCCOMPLEXPROPERTYTEMPLATETYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -328,6 +334,12 @@
     "name": "IFCCOSTSCHEDULETYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTVALUE",
+    "baseType": "",
+    "description": "Cost value reference",
+    "category": "reference"
   },
   {
     "name": "IFCCOUNTMEASURE",
@@ -443,6 +455,12 @@
     "name": "IFCDOCUMENTCONFIDENTIALITYENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTREFERENCE",
+    "baseType": "",
+    "description": "Reference to an external document",
+    "category": "reference"
   },
   {
     "name": "IFCDOCUMENTSTATUSENUM",
@@ -613,6 +631,12 @@
     "name": "IFCEVENTTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEXTERNALREFERENCE",
+    "baseType": "",
+    "description": "Reference to an external source (classification, document or library)",
+    "category": "reference"
   },
   {
     "name": "IFCEXTERNALSPATIALELEMENTTYPEENUM",
@@ -960,6 +984,12 @@
     "description": "Measure value (decimal)"
   },
   {
+    "name": "IFCMATERIALDEFINITION",
+    "baseType": "",
+    "description": "Reference to a material definition",
+    "category": "reference"
+  },
+  {
     "name": "IFCMECHANICALFASTENERTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -1098,6 +1128,12 @@
     "name": "IFCPERMITTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERSON",
+    "baseType": "",
+    "description": "Reference to a person",
+    "category": "reference"
   },
   {
     "name": "IFCPHMEASURE",
@@ -1633,6 +1669,12 @@
     "name": "IFCTIMEMEASURE",
     "baseType": "xs:double",
     "description": "Time measurement"
+  },
+  {
+    "name": "IFCTIMESERIES",
+    "baseType": "",
+    "description": "Reference to a time series",
+    "category": "reference"
   },
   {
     "name": "IFCTIMESERIESDATATYPEENUM",

--- a/lib/ids-client-validation.ts
+++ b/lib/ids-client-validation.ts
@@ -92,7 +92,7 @@ export async function validateGraphClientSide(
         // for a template IFCLENGTHMEASURE) are treated as valid and never
         // surfaced; only a fundamentally different kind of value is hinted.
         if (data.dataType && data.baseName) {
-            const validation = isPropertyDataTypeValid(data.baseName, data.dataType)
+            const validation = isPropertyDataTypeValid(data.baseName, data.dataType, data.propertySet)
             if (!validation.valid && validation.expectedTypes) {
                 issues.push({
                     severity: 'warning',

--- a/lib/ifc-schema.ts
+++ b/lib/ifc-schema.ts
@@ -44,6 +44,11 @@ interface IFCSimpleType {
   name: string
   baseType: string
   description?: string
+  // Set to 'reference' for entity/reference value types (IfcDocumentReference,
+  // IfcExternalReference, …) that standard IFC pset templates use but which have
+  // no simple-value restriction base. See scripts/generate-ids-datatypes.mjs and
+  // issue #58.
+  category?: string
 }
 
 interface IFCPropertySetDefinition {
@@ -202,6 +207,11 @@ const validDataTypeCache = new Set<string>()
 // Datatype name (UPPERCASE) -> xs: restriction base type (e.g. "xs:double").
 // Used to group datatypes into coarse value categories for compatibility hints.
 const dataTypeBaseTypeCache = new Map<string, string>()
+// Datatype names (UPPERCASE) flagged category:'reference' in the schema — the
+// entity/reference value types (IfcDocumentReference, …) that carry no simple
+// restriction base. Kept out of the numeric/string/… categories so they never
+// produce a "different kind of value" recommendation (issue #58).
+const referenceDataTypeCache = new Set<string>()
 let simpleTypesCacheVersion: IFCVersion | null = null
 
 async function ensureSimpleTypeCaches(version: IFCVersion): Promise<void> {
@@ -211,10 +221,12 @@ async function ensureSimpleTypeCaches(version: IFCVersion): Promise<void> {
     if (simpleTypes.length === 0) return // keep any existing cache / legacy fallback
     validDataTypeCache.clear()
     dataTypeBaseTypeCache.clear()
+    referenceDataTypeCache.clear()
     for (const t of simpleTypes) {
       const upper = t.name.toUpperCase()
       validDataTypeCache.add(upper)
       dataTypeBaseTypeCache.set(upper, (t.baseType || '').trim())
+      if (t.category === 'reference') referenceDataTypeCache.add(upper)
     }
     simpleTypesCacheVersion = version
   } catch (error) {
@@ -249,6 +261,9 @@ export type DataTypeCategory =
   | 'boolean'
   | 'datetime'
   | 'binary'
+  // Entity/reference value types (IfcDocumentReference, IfcExternalReference, …).
+  // Treated like 'unknown' for compatibility so they never drive a hint.
+  | 'reference'
   | 'unknown'
 
 function baseTypeToCategory(base: string): DataTypeCategory {
@@ -275,7 +290,11 @@ function baseTypeToCategory(base: string): DataTypeCategory {
 }
 
 export function getDataTypeCategory(dataType: string): DataTypeCategory {
-  const base = dataTypeBaseTypeCache.get(dataType.toUpperCase())
+  const upper = dataType.toUpperCase()
+  // Reference value types have an empty restriction base (which would otherwise
+  // fall into 'binary'); classify them explicitly so they stand apart. (#58)
+  if (referenceDataTypeCache.has(upper)) return 'reference'
+  const base = dataTypeBaseTypeCache.get(upper)
   if (base === undefined) return 'unknown'
   return baseTypeToCategory(base)
 }
@@ -289,7 +308,11 @@ export function areDataTypesCompatible(a: string, b: string): boolean {
   if (a.toUpperCase() === b.toUpperCase()) return true
   const ca = getDataTypeCategory(a)
   const cb = getDataTypeCategory(b)
+  // Unknown or reference value types are opaque — never flag them as a
+  // "different kind of value" (idsedit's pset template data can collapse a
+  // reference type to IFCLABEL, so a mismatch here would be a false hint). (#58)
   if (ca === 'unknown' || cb === 'unknown') return true
+  if (ca === 'reference' || cb === 'reference') return true
   return ca === cb
 }
 
@@ -459,8 +482,20 @@ export async function getSchemaStats(): Promise<{ version: string; entityCount: 
 
 // Build a cache of property name to data types from loaded property sets
 const propertyDataTypeCache = new Map<string, Set<string>>()
+// Property-set-scoped expected datatypes, keyed by `PSET PROP` (uppercase).
+// Lets the recommendation check ask "what type does THIS pset give THIS
+// property" instead of unioning a name across every pset — which previously
+// mis-hinted custom-pset properties that happen to share a standard name (e.g.
+// NOBN_SurveyControlStation.Elevation vs the standard length-typed Elevation).
+const propertySetScopedDataTypeCache = new Map<string, Set<string>>()
+// Uppercased names of every standard IFC property set we know about. Used to
+// tell a recognized pset from a project-specific/custom one.
+const knownPropertySetNames = new Set<string>()
 let cacheBuilt = false
 let cacheVersion: IFCVersion | null = null
+
+const scopedKey = (psetName: string, propName: string) =>
+  `${psetName.toUpperCase()} ${propName.toUpperCase()}`
 
 async function buildPropertyDataTypeCache(version: IFCVersion) {
   // Rebuild if version changed
@@ -470,17 +505,26 @@ async function buildPropertyDataTypeCache(version: IFCVersion) {
     // Clear previous cache if version changed
     if (cacheVersion !== version) {
       propertyDataTypeCache.clear()
+      propertySetScopedDataTypeCache.clear()
+      knownPropertySetNames.clear()
       cacheBuilt = false
     }
 
     const allPropertySets = await getAllPropertySets(version)
 
     for (const pset of allPropertySets) {
+      knownPropertySetNames.add(pset.name.toUpperCase())
       for (const prop of pset.properties) {
         if (!propertyDataTypeCache.has(prop.name)) {
           propertyDataTypeCache.set(prop.name, new Set())
         }
         propertyDataTypeCache.get(prop.name)!.add(prop.dataType)
+
+        const key = scopedKey(pset.name, prop.name)
+        if (!propertySetScopedDataTypeCache.has(key)) {
+          propertySetScopedDataTypeCache.set(key, new Set())
+        }
+        propertySetScopedDataTypeCache.get(key)!.add(prop.dataType)
       }
     }
 
@@ -553,6 +597,45 @@ export async function getExpectedDataTypesForPropertyAsync(propertyName: string,
 }
 
 /**
+ * Whether `propertySetName` is a recognized standard IFC property set (as
+ * opposed to a project-specific / custom one). Only meaningful once the cache
+ * is built; returns false beforehand so callers stay lenient.
+ */
+export function isKnownPropertySet(propertySetName: string): boolean {
+  // A property node may carry its pset as a restriction object rather than a
+  // plain string; anything non-string can't be a recognized standard pset.
+  if (!propertySetName || typeof propertySetName !== 'string') return false
+  return knownPropertySetNames.has(propertySetName.toUpperCase())
+}
+
+/**
+ * Expected datatypes for a property *within a specific property set*. Unlike
+ * getExpectedDataTypesForProperty (which unions a property name across every
+ * pset), this only speaks for the given standard pset:
+ *  - custom / unknown pset            → undefined (author owns the definition)
+ *  - standard pset, property present  → that property's template datatype(s)
+ *  - standard pset, property absent   → undefined (custom property added to a
+ *                                       standard pset; no template opinion)
+ */
+export function getExpectedDataTypesForPropertyInSet(
+  propertySetName: string,
+  propertyName: string,
+): string[] | undefined {
+  if (!isKnownPropertySet(propertySetName)) return undefined
+
+  const direct = propertySetScopedDataTypeCache.get(scopedKey(propertySetName, propertyName))
+  if (direct) return Array.from(direct)
+
+  const normalized = normalizePropertyName(propertyName)
+  if (normalized !== propertyName) {
+    const viaNormalized = propertySetScopedDataTypeCache.get(scopedKey(propertySetName, normalized))
+    if (viaNormalized) return Array.from(viaNormalized)
+  }
+
+  return undefined
+}
+
+/**
  * Compares a property's chosen datatype against the datatype(s) used for that
  * property name in the standard IFC property-set templates.
  *
@@ -566,9 +649,24 @@ export async function getExpectedDataTypesForPropertyAsync(propertyName: string,
  *     uses a measure) → `valid: false` + `expectedTypes`, surfaced by callers as
  *     a non-blocking recommendation.
  * Custom / unknown properties carry no template opinion and are always valid.
+ *
+ * When `propertySetName` is supplied the comparison is scoped to that property
+ * set: a property in a custom pset — or a custom property in a standard pset —
+ * carries no template opinion, so it's always valid. This prevents mis-hinting
+ * a project-specific property that merely shares a name with a standard one
+ * (e.g. NOBN_SurveyControlStation.Elevation vs the standard length Elevation).
  */
-export function isPropertyDataTypeValid(propertyName: string, dataType: string): { valid: boolean; expectedTypes?: string[] } {
-  const expectedTypes = getExpectedDataTypesForProperty(propertyName)
+export function isPropertyDataTypeValid(
+  propertyName: string,
+  dataType: string,
+  propertySetName?: string,
+): { valid: boolean; expectedTypes?: string[] } {
+  // Prefer the pset-scoped opinion when we know which pset this is; only fall
+  // back to the name-only union when no pset is given (backward compatible).
+  const expectedTypes =
+    propertySetName !== undefined
+      ? getExpectedDataTypesForPropertyInSet(propertySetName, propertyName)
+      : getExpectedDataTypesForProperty(propertyName)
 
   // If no expected types defined, any valid IFC data type is acceptable (custom property)
   if (!expectedTypes) {

--- a/public/generated/simple-types-ifc4.json
+++ b/public/generated/simple-types-ifc4.json
@@ -205,6 +205,12 @@
     "description": "Enumeration value"
   },
   {
+    "name": "IFCCOMPLEXNUMBER",
+    "baseType": "",
+    "description": "Complex number (reference value)",
+    "category": "reference"
+  },
+  {
     "name": "IFCCOMPLEXPROPERTYTEMPLATETYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -545,6 +551,12 @@
     "description": "Enumeration value"
   },
   {
+    "name": "IFCEXTERNALREFERENCE",
+    "baseType": "",
+    "description": "Reference to an external source (classification, document or library)",
+    "category": "reference"
+  },
+  {
     "name": "IFCEXTERNALSPATIALELEMENTTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -850,6 +862,12 @@
     "description": "Measure value (decimal)"
   },
   {
+    "name": "IFCMATERIALDEFINITION",
+    "baseType": "",
+    "description": "Reference to a material definition",
+    "category": "reference"
+  },
+  {
     "name": "IFCMECHANICALFASTENERTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -978,6 +996,12 @@
     "name": "IFCPERMITTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERSON",
+    "baseType": "",
+    "description": "Reference to a person",
+    "category": "reference"
   },
   {
     "name": "IFCPHMEASURE",
@@ -1470,6 +1494,12 @@
     "description": "Time measurement"
   },
   {
+    "name": "IFCTIMESERIES",
+    "baseType": "",
+    "description": "Reference to a time series",
+    "category": "reference"
+  },
+  {
     "name": "IFCTIMESERIESDATATYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -1518,6 +1548,12 @@
     "name": "IFCURIREFERENCE",
     "baseType": "xs:string",
     "description": "Text or identifier value"
+  },
+  {
+    "name": "IFCVALUE",
+    "baseType": "",
+    "description": "Any IFC value (measure, simple or derived value)",
+    "category": "reference"
   },
   {
     "name": "IFCVALVETYPEENUM",

--- a/public/generated/simple-types-ifc4x3_add2.json
+++ b/public/generated/simple-types-ifc4x3_add2.json
@@ -255,6 +255,12 @@
     "description": "Enumeration value"
   },
   {
+    "name": "IFCCOMPLEXNUMBER",
+    "baseType": "",
+    "description": "Complex number (reference value)",
+    "category": "reference"
+  },
+  {
     "name": "IFCCOMPLEXPROPERTYTEMPLATETYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -328,6 +334,12 @@
     "name": "IFCCOSTSCHEDULETYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCCOSTVALUE",
+    "baseType": "",
+    "description": "Cost value reference",
+    "category": "reference"
   },
   {
     "name": "IFCCOUNTMEASURE",
@@ -443,6 +455,12 @@
     "name": "IFCDOCUMENTCONFIDENTIALITYENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCDOCUMENTREFERENCE",
+    "baseType": "",
+    "description": "Reference to an external document",
+    "category": "reference"
   },
   {
     "name": "IFCDOCUMENTSTATUSENUM",
@@ -613,6 +631,12 @@
     "name": "IFCEVENTTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCEXTERNALREFERENCE",
+    "baseType": "",
+    "description": "Reference to an external source (classification, document or library)",
+    "category": "reference"
   },
   {
     "name": "IFCEXTERNALSPATIALELEMENTTYPEENUM",
@@ -960,6 +984,12 @@
     "description": "Measure value (decimal)"
   },
   {
+    "name": "IFCMATERIALDEFINITION",
+    "baseType": "",
+    "description": "Reference to a material definition",
+    "category": "reference"
+  },
+  {
     "name": "IFCMECHANICALFASTENERTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
@@ -1098,6 +1128,12 @@
     "name": "IFCPERMITTYPEENUM",
     "baseType": "xs:string",
     "description": "Enumeration value"
+  },
+  {
+    "name": "IFCPERSON",
+    "baseType": "",
+    "description": "Reference to a person",
+    "category": "reference"
   },
   {
     "name": "IFCPHMEASURE",
@@ -1633,6 +1669,12 @@
     "name": "IFCTIMEMEASURE",
     "baseType": "xs:double",
     "description": "Time measurement"
+  },
+  {
+    "name": "IFCTIMESERIES",
+    "baseType": "",
+    "description": "Reference to a time series",
+    "category": "reference"
   },
   {
     "name": "IFCTIMESERIESDATATYPEENUM",

--- a/scripts/generate-ids-datatypes.mjs
+++ b/scripts/generate-ids-datatypes.mjs
@@ -37,6 +37,57 @@ const OUT_DIRS = [
   join(repoRoot, 'public', 'generated'),
 ]
 
+// Reference / object-value datatypes that the official DataTypes.md table does
+// NOT list, but which the buildingSMART IDS-Audit-Tool nonetheless accepts as a
+// property `dataType` — because standard IFC property-set templates declare
+// properties of these types (e.g. Pset_ManufacturerTypeInformation.
+// PerformanceCertificate is an IfcDocumentReference, OperationalDocument is an
+// IfcExternalReference). These are the entity/reference value types carried by
+// IfcPropertyReferenceValue et al., so they never appear in the "simple value"
+// DataTypes table, yet a valid IDS may legitimately use them (see issue #58 —
+// a BIMQ-exported, officially-valid IFC4X3 file was flagged with 81 false
+// "Invalid IFC data type" errors solely because these were missing here).
+//
+// The set below was derived from the authoritative pset templates embedded in
+// the IDS-Audit-Tool (ids-lib · SchemaInfo.Properties.g.cs): for each schema
+// version it is exactly the datatypes referenced by that version's standard
+// property templates that are absent from the general DataTypes.md list. They
+// have no xs restriction base type (you cannot xs:restrict a reference value),
+// so `baseType` is empty; `lib/ifc-schema.ts` classifies them in a dedicated
+// "reference" value category so they never trigger a datatype recommendation.
+const REFERENCE_DATA_TYPES = {
+  ifc2x3: [],
+  ifc4: [
+    'IFCCOMPLEXNUMBER',
+    'IFCEXTERNALREFERENCE',
+    'IFCMATERIALDEFINITION',
+    'IFCPERSON',
+    'IFCTIMESERIES',
+    'IFCVALUE',
+  ],
+  ifc4x3_add2: [
+    'IFCCOMPLEXNUMBER',
+    'IFCCOSTVALUE',
+    'IFCDOCUMENTREFERENCE',
+    'IFCEXTERNALREFERENCE',
+    'IFCMATERIALDEFINITION',
+    'IFCPERSON',
+    'IFCTIMESERIES',
+  ],
+}
+
+// Human descriptions for the reference datatypes above.
+const REFERENCE_DATA_TYPE_DESCRIPTIONS = {
+  IFCCOMPLEXNUMBER: 'Complex number (reference value)',
+  IFCCOSTVALUE: 'Cost value reference',
+  IFCDOCUMENTREFERENCE: 'Reference to an external document',
+  IFCEXTERNALREFERENCE: 'Reference to an external source (classification, document or library)',
+  IFCMATERIALDEFINITION: 'Reference to a material definition',
+  IFCPERSON: 'Reference to a person',
+  IFCTIMESERIES: 'Reference to a time series',
+  IFCVALUE: 'Any IFC value (measure, simple or derived value)',
+}
+
 /** Parse the markdown dataType table into rows. */
 function parseTable(md) {
   const rows = []
@@ -125,12 +176,38 @@ function main() {
         description: descriptions.get(r.name) || fallbackDescription(r.name, r.baseType),
       }))
 
+    // Union in the reference/object-value datatypes for this schema version
+    // (see REFERENCE_DATA_TYPES above). Skip any that the table already lists.
+    const existing = new Set(list.map((t) => t.name))
+    let refAdded = 0
+    for (const name of REFERENCE_DATA_TYPES[suffix] || []) {
+      if (existing.has(name)) continue
+      list.push({
+        name,
+        baseType: '',
+        description:
+          descriptions.get(name) ||
+          REFERENCE_DATA_TYPE_DESCRIPTIONS[name] ||
+          'Reference value',
+        // Marks a value carried by reference (IfcPropertyReferenceValue et al.),
+        // not a restrictable simple value. Consumed by lib/ifc-schema.ts to keep
+        // these out of the numeric/string/… compatibility categories.
+        category: 'reference',
+      })
+      existing.add(name)
+      refAdded++
+    }
+    // Keep the file stably sorted by name so diffs stay minimal on regen.
+    list.sort((a, b) => a.name.localeCompare(b.name))
+
     const json = JSON.stringify(list, null, 2) + '\n'
     for (const dir of OUT_DIRS) {
       writeFileSync(join(dir, `simple-types-${suffix}.json`), json)
     }
     const hasPos = list.some((t) => t.name === 'IFCPOSITIVELENGTHMEASURE')
-    console.log(`  ${suffix}: ${list.length} datatypes (IFCPOSITIVELENGTHMEASURE: ${hasPos ? 'yes' : 'NO'})`)
+    console.log(
+      `  ${suffix}: ${list.length} datatypes (${refAdded} reference types added; IFCPOSITIVELENGTHMEASURE: ${hasPos ? 'yes' : 'NO'})`,
+    )
   }
   console.log(`Done. Parsed ${rows.length} rows from ${SOURCE}`)
 }


### PR DESCRIPTION
Closes #58.

### The bug
A BIMQ-exported IFC4X3 IDS (KIM v1.1.0, Bane NOR) that the **official buildingSMART IDS-Audit-Tool and xbim.it both report as valid** was flagged in IDSedit with **81 "Invalid IFC data type" errors** — every property typed `IfcDocumentReference` (47) or `IfcExternalReference` (34).

### Root cause
IDSedit validated a property `dataType` by flat membership in the per-version datatype allowlist, which is generated from the official `DataTypes.md` table. That table only covers simple *value* types (measures, enums, `IfcLabel`, …). It deliberately omits the entity/reference value types (`IfcDocumentReference`, `IfcExternalReference`, `IfcTimeSeries`, …) that standard IFC pset templates use via `IfcPropertyReferenceValue` — e.g. `Pset_ManufacturerTypeInformation.PerformanceCertificate` **is** an `IfcDocumentReference`. The official Audit-Tool accepts these because it checks a property's declared template type; our flat list did not, so every such property hard-errored.

### Fix
- Derive — from the authoritative pset templates embedded in the IDS-Audit-Tool (`ids-lib · SchemaInfo.Properties.g.cs`) — the reference/object-value datatypes each schema version's standard properties use but that `DataTypes.md` lacks, and union them into the generated `simple-types-*.json` allowlist (7 for IFC4X3, 6 for IFC4). `generate-ids-datatypes.mjs` now emits them, tagged `category:"reference"`.
- Give reference types their own value category in `ifc-schema.ts` so they never drive a "different kind of value" recommendation.
- Make the datatype recommendation **property-set-scoped**: only opine on datatypes for recognized standard psets, so a custom-pset property that merely shares a name with a standard one (e.g. `NOBN_SurveyControlStation.Elevation` vs the standard length `Elevation`) is no longer mis-hinted.

### Verification
Ran the real parser + validator pipeline on the reported file:

| | errors | warnings |
|---|---|---|
| before | **81** | 1 |
| after | **0** | 0 |

This matches the official IDS-Audit-Tool (`Completed with status: Ok`) and xbim. Guard-tested that a genuinely bogus datatype still errors and a real wrong-type-in-standard-pset still hints; the default canvas still validates clean. Confirmed live in the app ("Valid IDS" on the imported 889-node file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client-side property validation so datatype checks now account for property-set context, reducing false warnings.
  * Expanded accepted IFC datatype lists to include additional reference/object-value types, improving compatibility with more models.
* **Chores**
  * Regenerated datatype allowlists with more stable ordering and clearer logging during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->